### PR TITLE
optimize buttons and texts for IllustrationViewerPage

### DIFF
--- a/src/Pixeval/Pages/IllustrationViewer/IllustrationViewerPage.xaml
+++ b/src/Pixeval/Pages/IllustrationViewer/IllustrationViewerPage.xaml
@@ -40,15 +40,18 @@
                 <AppBarButton Click="BookmarkButton_OnClick"
                               Icon="{x:Bind illustrationViewer:IllustrationViewerPage.GetBookmarkButtonIcon(_viewModel.First.IsBookmarked), Mode=OneWay}"
                               Label="{x:Bind illustrationViewer:IllustrationViewerPage.GetBookmarkButtonLabel(_viewModel.First.IsBookmarked), Mode=OneWay}" />
+                <AppBarToggleButton x:Uid="/IllustrationViewerPage/IllustrationInfoAndCommentsButton"
+                                    Icon="{ui:FontIcon Glyph=InfoE946}"
+                                    IsChecked="{x:Bind IllustrationInfoAndCommentsSplitView.IsPaneOpen, Mode=TwoWay}" />
                 <AppBarSeparator />
-                <AppBarButton Width="40"
+                <AppBarButton Width="32"
                               Click="ZoomInButton_OnClick"
                               LabelPosition="Collapsed">
                     <AppBarButton.Icon>
                         <SymbolIcon Symbol="ZoomIn" />
                     </AppBarButton.Icon>
                 </AppBarButton>
-                <AppBarButton Width="40"
+                <AppBarButton Width="32"
                               Click="ZoomOutButton_OnClick"
                               LabelPosition="Collapsed">
                     <AppBarButton.Icon>
@@ -56,7 +59,7 @@
                     </AppBarButton.Icon>
                 </AppBarButton>
                 <AppBarButton x:Uid="/IllustrationViewerPage/PlayGifButton"
-                              Width="40"
+                              Width="32"
                               Click="PlayGifButton_OnClick"
                               LabelPosition="Collapsed"
                               Visibility="{x:Bind _viewModel.IsUgoira}">
@@ -65,6 +68,9 @@
                     </AppBarButton.Icon>
                 </AppBarButton>
                 <AppBarSeparator />
+                <AppBarButton x:Uid="/IllustrationViewerPage/CopyContentButton"
+                              Command="{x:Bind _copyCommand}"
+                              Icon="{ui:FontIcon Glyph=CopyE8C8}" />
                 <AppBarButton x:Uid="/IllustrationViewerPage/SaveCurrentImageButton"
                               Click="SaveCurrentImageButton_OnClick"
                               Icon="{ui:FontIcon Glyph=SaveE74E}" />
@@ -93,13 +99,6 @@
                 <AppBarButton x:Uid="/IllustrationViewerPage/ShareButton"
                               Click="ShareButton_OnClick"
                               Icon="{ui:FontIcon Glyph=ShareE72D}" />
-                <AppBarSeparator />
-                <AppBarButton x:Uid="/IllustrationViewerPage/CopyContentButton"
-                              Command="{x:Bind _copyCommand}"
-                              Icon="{ui:FontIcon Glyph=CopyE8C8}" />
-                <AppBarToggleButton x:Uid="/IllustrationViewerPage/IllustrationInfoAndCommentsButton"
-                                    Icon="{ui:FontIcon Glyph=InfoE946}"
-                                    IsChecked="{x:Bind IllustrationInfoAndCommentsSplitView.IsPaneOpen, Mode=TwoWay}" />
             </CommandBar>
             <TeachingTip x:Name="GenerateLinkToThisPageButtonTeachingTip"
                          x:Uid="/IllustrationViewerPage/GenerateLinkToThisPageButtonTeachingTip"

--- a/src/Pixeval/Strings/zh-CN/IllustrationViewerPage.resw
+++ b/src/Pixeval/Strings/zh-CN/IllustrationViewerPage.resw
@@ -133,7 +133,7 @@
     <value>复制</value>
   </data>
   <data name="GenerateLinkToThisPageButton.Label" xml:space="preserve">
-    <value>生成本页链接</value>
+    <value>生成链接</value>
   </data>
   <data name="GenerateLinkToThisPageButtonTeachingTip.ActionButtonContent" xml:space="preserve">
     <value>不再显示</value>
@@ -148,19 +148,19 @@
     <value>链接已经复制到剪切板</value>
   </data>
   <data name="GenerateWebLinkButton.Label" xml:space="preserve">
-    <value>生成网页链接</value>
+    <value>生成网址</value>
   </data>
   <data name="IllustrationInfoAndCommentsButton.Label" xml:space="preserve">
-    <value>作品详情与评论</value>
+    <value>详情</value>
   </data>
   <data name="IllustrationInfoTab.Content" xml:space="preserve">
-    <value>作品信息</value>
+    <value>详情</value>
   </data>
   <data name="OpenInWebBrowserButton.Label" xml:space="preserve">
-    <value>在浏览器中查看</value>
+    <value>打开网页</value>
   </data>
   <data name="PlayGifButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>播放/暂停GIF图片</value>
+    <value>播放/暂停GIF</value>
   </data>
   <data name="RemoveBookmark" xml:space="preserve">
     <value>取消收藏</value>
@@ -175,7 +175,7 @@
     <value>图集另存为</value>
   </data>
   <data name="SaveMangaButton.Label" xml:space="preserve">
-    <value>保存图集</value>
+    <value>图集保存</value>
   </data>
   <data name="ShareButton.Label" xml:space="preserve">
     <value>分享</value>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12800094/132202751-8a34b717-7a44-470f-a19c-5524e6425577.png)

So users can copy with "Ctrl+V" easier.

Known bug: "COPY" button cannot be enabled when image is loaded, and only works when resizing the window horizontally to let the button status be refreshed. 