### PR TITLE
Fix IllustratorPage

### DIFF
--- a/src/Pixeval.CoreApi/Engine/AbstractPixivAsyncEnumerator.cs
+++ b/src/Pixeval.CoreApi/Engine/AbstractPixivAsyncEnumerator.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Pixeval.CoreApi.Global.Exception;
 using Pixeval.CoreApi.Net;
@@ -107,12 +108,12 @@ public abstract class AbstractPixivAsyncEnumerator<TEntity, TRawEntity, TFetchEn
             var result = (await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false)).FromJson<TRawEntity>();
             if (result is null)
             {
-                return Result<TRawEntity>.OfFailure();
+                return Result<TRawEntity>.OfFailure(new MakoNetworkException(url, MakoClient.Configuration.Bypass, "null or empty response", (int)responseMessage.StatusCode));
             }
 
             return ValidateResponse(result)
                 ? Result<TRawEntity>.OfSuccess(result)
-                : Result<TRawEntity>.OfFailure();
+                : Result<TRawEntity>.OfFailure(new MakoNetworkException(url, MakoClient.Configuration.Bypass, "invalid response", (int)responseMessage.StatusCode));
         }
         catch (HttpRequestException e)
         {

--- a/src/Pixeval.CoreApi/Net/RetryHttpClientHandler.cs
+++ b/src/Pixeval.CoreApi/Net/RetryHttpClientHandler.cs
@@ -43,7 +43,7 @@ internal class RetryHttpClientHandler : HttpMessageHandler
         return await Functions.RetryAsync(() => _delegatedHandler.SendAsync(request, cancellationToken), 2, _timeout).ConfigureAwait(false) switch
         {
             Result<HttpResponseMessage>.Success(var response) => response,
-            Result<HttpResponseMessage>.Failure failure => throw failure.Cause ?? new HttpRequestException(),
+            Result<HttpResponseMessage>.Failure failure => throw failure.Cause,
             _ => throw new InvalidOperationException("Unexpected case")
         };
     }
@@ -66,7 +66,7 @@ internal class MakoRetryHttpClientHandler : HttpMessageHandler, IMakoClientSuppo
         return await Functions.RetryAsync(() => _delegatedHandler.SendAsync(request, cancellationToken), 2, MakoClient!.Configuration.ConnectionTimeout).ConfigureAwait(false) switch
         {
             Result<HttpResponseMessage>.Success(var response) => response,
-            Result<HttpResponseMessage>.Failure failure => throw failure.Cause ?? new HttpRequestException(),
+            Result<HttpResponseMessage>.Failure failure => throw failure.Cause,
             _ => throw new InvalidOperationException("Unexpected case")
         };
     }

--- a/src/Pixeval.Utilities/Functions.cs
+++ b/src/Pixeval.Utilities/Functions.cs
@@ -66,7 +66,7 @@ public static class Functions
             return Result<TResult>.OfSuccess(task.Result);
         }
 
-        return Result<TResult>.OfFailure();
+        return Result<TResult>.OfFailure(new TimeoutException($"Task exceed {timeoutMills}ms timeout"));
     }
 
     public static async Task<Result<TResult>> RetryAsync<TResult>(Func<Task<TResult>> body, int attempts = 3, int timeoutMills = 0)

--- a/src/Pixeval.Utilities/Objects.cs
+++ b/src/Pixeval.Utilities/Objects.cs
@@ -163,7 +163,9 @@ public static class Objects
     public static async Task<Result<string>> GetStringResultAsync(this HttpClient httpClient, string url, Func<HttpResponseMessage, Task<Exception>>? exceptionSelector = null)
     {
         var responseMessage = await httpClient.GetAsync(url).ConfigureAwait(false);
-        return !responseMessage.IsSuccessStatusCode ? Result<string>.OfFailure(exceptionSelector is { } selector ? await selector.Invoke(responseMessage).ConfigureAwait(false) : null) : Result<string>.OfSuccess(await responseMessage.Content.ReadAsStringAsync());
+        return !responseMessage.IsSuccessStatusCode 
+            ? Result<string>.OfFailure(exceptionSelector is { } selector ? await selector.Invoke(responseMessage).ConfigureAwait(false) : new HttpRequestException($"Non-successful request of {url}: {responseMessage.ReasonPhrase}", null, responseMessage.StatusCode))
+            : Result<string>.OfSuccess(await responseMessage.Content.ReadAsStringAsync());
     }
 
     public static Task<TResult[]> WhenAll<TResult>(this IEnumerable<Task<TResult>> tasks)

--- a/src/Pixeval.Utilities/Result.cs
+++ b/src/Pixeval.Utilities/Result.cs
@@ -33,7 +33,7 @@ public record Result<T>
     return this switch
     {
         Success(var content) => content,
-        Failure(var cause) => throw cause ?? new Exception("This is an exception thrown by Result.Failure"),
+        Failure(var cause) => throw cause,
         _ => throw new Exception("Invalid derived type of Result<T>")
     };
 }
@@ -56,7 +56,7 @@ public static Result<T> OfSuccess(T value)
 }
 
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-public static Result<T> OfFailure(Exception? cause = null)
+public static Result<T> OfFailure(Exception cause)
 {
     return new Failure(cause);
 }
@@ -96,9 +96,9 @@ public record Success(T Value) : Result<T>
 }
 
 [PublicAPI]
-public record Failure(Exception? Cause) : Result<T>
+public record Failure(Exception Cause) : Result<T>
     {
-    public void Deconstruct(out Exception? cause)
+    public void Deconstruct(out Exception cause)
     {
         cause = Cause;
     }

--- a/src/Pixeval/Controls/IllustratorView/IllustratorPageIllustratorModel.cs
+++ b/src/Pixeval/Controls/IllustratorView/IllustratorPageIllustratorModel.cs
@@ -34,7 +34,7 @@ using IllustrationViewModel = Pixeval.UserControls.IllustrationView.Illustration
 
 namespace Pixeval.Controls.IllustratorView;
 
-public partial class IllustratorViewModel : ObservableObject, IIllustrationVisualizer
+public partial class IllustratorPageIllustratorModel : ObservableObject, IIllustrationVisualizer
 {
     public string Name { get; set; }
 
@@ -64,7 +64,7 @@ public partial class IllustratorViewModel : ObservableObject, IIllustrationVisua
 
     public IllustrationVisualizationController VisualizationController { get; internal set; }
 
-    public IllustratorViewModel(UserInfo info)
+    public IllustratorPageIllustratorModel(UserInfo info, ImageSource? avatarSource)
     {
         Name = info.Name!;
         AvatarUrl = info.ProfileImageUrls?.Medium!;
@@ -75,6 +75,7 @@ public partial class IllustratorViewModel : ObservableObject, IIllustrationVisua
         Illustrations = new ObservableCollection<IllustrationViewModel>();
         VisualizationController = new IllustrationVisualizationController(this);
         IsFollowButtonEnabled = true;
+        AvatarSource = avatarSource;
         _ = LoadAvatar();
     }
 

--- a/src/Pixeval/Controls/IllustratorView/IllustratorView.cs
+++ b/src/Pixeval/Controls/IllustratorView/IllustratorView.cs
@@ -35,7 +35,7 @@ namespace Pixeval.Controls.IllustratorView;
 [DependencyProperty<object>("ThumbnailSources")]
 [DependencyProperty<object>("ThumbnailItemTemplate")]
 [DependencyProperty<ImageSource>("IllustratorPicture")]
-[DependencyProperty<IllustratorViewModel>("ViewModel")]
+[DependencyProperty<IllustratorPageIllustratorModel>("ViewModel")]
 public partial class IllustratorView : Control
 {
     private const string PartContentContainer = "ContentContainer";

--- a/src/Pixeval/Pages/Capability/FollowingsPage.xaml.cs
+++ b/src/Pixeval/Pages/Capability/FollowingsPage.xaml.cs
@@ -59,12 +59,12 @@ public sealed partial class FollowingsPage
 
     private void IllustratorView_OnUserTapped(object sender, TappedRoutedEventArgs e)
     {
-        // var context = sender.GetDataContext<IllustratorViewModel>();
-        // var item = IllustratorView.GetItemContainer(context);
-        // ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("ForwardConnectedAnimation", item);
-        // App.AppViewModel.RootFrameNavigate(typeof(IllustratorPage), null, new SlideNavigationTransitionInfo
-        // {
-        //     Effect = SlideNavigationTransitionEffect.FromRight
-        // });
+        var context = sender.GetDataContext<IllustratorViewModel>();
+        var item = IllustratorView.GetItemContainer(context);
+        ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("ForwardConnectedAnimation", item);
+        App.AppViewModel.RootFrameNavigate(typeof(IllustratorPage), context, new SlideNavigationTransitionInfo
+        {
+            Effect = SlideNavigationTransitionEffect.FromRight
+        });
     }
 }

--- a/src/Pixeval/Pages/IllustrationViewer/IllustrationInfoPage.xaml.cs
+++ b/src/Pixeval/Pages/IllustrationViewer/IllustrationInfoPage.xaml.cs
@@ -71,7 +71,7 @@ public sealed partial class IllustrationInfoPage
         if (_viewModel.UserInfo is { } userInfo)
         {
             ConnectedAnimationService.GetForCurrentView().PrepareToAnimate("ForwardConnectedAnimation", (UIElement)sender);
-            App.AppViewModel.RootFrameNavigate(typeof(IllustratorPage), Tuple.Create((UIElement)sender, new IllustratorViewModel(userInfo)), new SlideNavigationTransitionInfo
+            App.AppViewModel.RootFrameNavigate(typeof(IllustratorPage), Tuple.Create((UIElement)sender, new IllustratorPageIllustratorModel(userInfo, _viewModel.UserProfileImageSource)), new SlideNavigationTransitionInfo
             {
                 Effect = SlideNavigationTransitionEffect.FromRight
             });

--- a/src/Pixeval/Pages/IllustratorViewer/IllustratorPage.xaml
+++ b/src/Pixeval/Pages/IllustratorViewer/IllustratorPage.xaml
@@ -12,86 +12,82 @@
                        Loaded="IllustratorPage_OnLoaded"
                        SizeChanged="IllustratorPage_OnSizeChanged"
                        mc:Ignorable="d">
-    <controls1:DockPanel x:Name="IllustrationPresenterDockPanel"
-                         HorizontalAlignment="Stretch"
-                         LastChildFill="True">
-        <userControls:IllustrationContainer x:Name="IllustrationContainer" controls1:DockPanel.Dock="Top">
-            <userControls:IllustrationContainer.Header>
-                <Grid x:Name="Header"
-                      Height="250"
-                      VerticalAlignment="Center"
-                      controls1:DockPanel.Dock="Top">
-                    <Rectangle x:Name="BackgroundRectangle"
-                               Height="250"
-                               HorizontalAlignment="Stretch"
-                               VerticalAlignment="Top">
-                        <Rectangle.Fill>
-                            <ImageBrush x:Name="BackgroundImage"
-                                        ImageSource="ms-appx:///Assets/Images/pixeval-mock.png"
-                                        Opacity="0.6"
-                                        Stretch="UniformToFill" />
-                        </Rectangle.Fill>
-                    </Rectangle>
-                    <Rectangle x:Name="OverlayRectangle"
-                               Height="250"
-                               HorizontalAlignment="Stretch"
-                               VerticalAlignment="Top"
-                               Fill="#BFCFB5C0" />
-                    <StackPanel x:Name="TextContainer"
-                                HorizontalAlignment="Left"
-                                Orientation="Horizontal">
-                        <Ellipse x:Name="ProfileImage"
-                                 Width="100"
-                                 Height="100"
-                                 Margin="20,65,20,0"
-                                 VerticalAlignment="Top">
-                            <Ellipse.Fill>
-                                <ImageBrush ImageSource="{x:Bind _viewModel.AvatarSource, Mode=OneWay}" Stretch="UniformToFill" />
-                            </Ellipse.Fill>
-                        </Ellipse>
-                        <StackPanel Margin="0,65,0,0"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Top"
-                                    Orientation="Vertical">
-                            <TextBlock x:Name="TitleBlock"
-                                       FontSize="20"
-                                       Foreground="White"
-                                       Text="{x:Bind _viewModel.Name, Mode=OneWay}" />
-                            <TextBlock x:Name="SubtitleBlock"
-                                       Margin="0,10,0,0"
-                                       FontSize="10"
-                                       Foreground="White"
-                                       Text="{x:Bind _viewModel.Id, Mode=OneWay}" />
-                            <TextBlock x:Name="Blurb"
-                                       Width="400"
-                                       Margin="0,20,0,0"
-                                       FontSize="12"
-                                       Foreground="White"
-                                       TextWrapping="Wrap">
-                                <Run Text="{x:Bind _viewModel.Comment}" />
-                            </TextBlock>
-                            <StackPanel Margin="-15,50,0,20" HorizontalAlignment="Left" VerticalAlignment="Bottom">
-                                <CommandBar x:Name="CommandBar"
-                                            Background="Transparent"
-                                            DefaultLabelPosition="Right">
-                                    <AppBarButton Tapped="OpenLinkButton_OnTapped" Command="{x:Bind OpenLinkCommand}"></AppBarButton>
-                                    <AppBarButton Tapped="FollowButton_OnTapped" IsEnabled="{x:Bind _viewModel.IsFollowButtonEnabled, Mode=OneWay}"  Visibility="{x:Bind _viewModel.IsNotFollowed(_viewModel.IsFollowed), Mode=OneWay}" Command="{x:Bind FollowCommand}"></AppBarButton>
-                                    <AppBarButton Tapped="PrivateFollowButton_OnTapped" IsEnabled="{x:Bind _viewModel.IsFollowButtonEnabled, Mode=OneWay}"  Visibility="{x:Bind _viewModel.IsNotFollowed(_viewModel.IsFollowed), Mode=OneWay}" Command="{x:Bind PrivateFollowCommand}"></AppBarButton>
-                                    <AppBarButton Tapped="UnfollowButton_OnTapped" IsEnabled="{x:Bind _viewModel.IsFollowButtonEnabled, Mode=OneWay}" Visibility="{x:Bind _viewModel.IsFollowed, Mode=OneWay}" Command="{x:Bind UnfollowCommand}"></AppBarButton>
 
-                                </CommandBar>
-                            </StackPanel>
+    <userControls:IllustrationContainer x:Name="IllustrationContainer" controls1:DockPanel.Dock="Top">
+        <userControls:IllustrationContainer.Header>
+            <Grid x:Name="Header"
+                  Height="250"
+                  VerticalAlignment="Center"
+                  controls1:DockPanel.Dock="Top">
+                <Rectangle x:Name="BackgroundRectangle"
+                           Height="250"
+                           HorizontalAlignment="Stretch"
+                           VerticalAlignment="Top">
+                    <Rectangle.Fill>
+                        <ImageBrush x:Name="BackgroundImage"
+                                    ImageSource="ms-appx:///Assets/Images/pixeval-mock.png"
+                                    Opacity="0.6"
+                                    Stretch="UniformToFill" />
+                    </Rectangle.Fill>
+                </Rectangle>
+                <Rectangle x:Name="OverlayRectangle"
+                           Height="250"
+                           HorizontalAlignment="Stretch"
+                           VerticalAlignment="Top"
+                           Fill="#BFCFB5C0" />
+                <StackPanel x:Name="TextContainer"
+                            HorizontalAlignment="Left"
+                            Orientation="Horizontal">
+                    <Ellipse x:Name="ProfileImage"
+                             Width="100"
+                             Height="100"
+                             Margin="20,65,20,0"
+                             VerticalAlignment="Top">
+                        <Ellipse.Fill>
+                            <ImageBrush ImageSource="{x:Bind ViewModel.IllustratorViewModel.AvatarSource, Mode=OneWay}" Stretch="UniformToFill" />
+                        </Ellipse.Fill>
+                    </Ellipse>
+                    <StackPanel Margin="0,65,0,0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top"
+                                Orientation="Vertical">
+                        <TextBlock x:Name="TitleBlock"
+                                   FontSize="20"
+                                   Foreground="White"
+                                   Text="{x:Bind ViewModel.IllustratorViewModel.Name, Mode=OneWay}" />
+                        <TextBlock x:Name="SubtitleBlock"
+                                   Margin="0,10,0,0"
+                                   FontSize="10"
+                                   Foreground="White"
+                                   Text="{x:Bind ViewModel.IllustratorViewModel.Id, Mode=OneWay}" />
+                        <TextBlock x:Name="Blurb"
+                                   Width="400"
+                                   Margin="0,20,0,0"
+                                   FontSize="12"
+                                   Foreground="White"
+                                   TextWrapping="Wrap">
+                            <Run Text="{x:Bind ViewModel.IllustratorViewModel.Comment}" />
+                        </TextBlock>
+                        <StackPanel Margin="-15,50,0,20" HorizontalAlignment="Left" VerticalAlignment="Bottom">
+                            <CommandBar x:Name="CommandBar"
+                                        Background="Transparent"
+                                        DefaultLabelPosition="Right">
+                                <AppBarButton Tapped="OpenLinkButton_OnTapped" Command="{x:Bind OpenLinkCommand}"></AppBarButton>
+                                <AppBarButton Tapped="FollowButton_OnTapped" IsEnabled="{x:Bind ViewModel.IllustratorViewModel.IsFollowButtonEnabled, Mode=OneWay}"  Visibility="{x:Bind ViewModel.IllustratorViewModel.IsNotFollowed(ViewModel.IllustratorViewModel.IsFollowed), Mode=OneWay}" Command="{x:Bind FollowCommand}"></AppBarButton>
+                                <AppBarButton Tapped="PrivateFollowButton_OnTapped" IsEnabled="{x:Bind ViewModel.IllustratorViewModel.IsFollowButtonEnabled, Mode=OneWay}"  Visibility="{x:Bind ViewModel.IllustratorViewModel.IsNotFollowed(ViewModel.IllustratorViewModel.IsFollowed), Mode=OneWay}" Command="{x:Bind PrivateFollowCommand}"></AppBarButton>
+                                <AppBarButton Tapped="UnfollowButton_OnTapped" IsEnabled="{x:Bind ViewModel.IllustratorViewModel.IsFollowButtonEnabled, Mode=OneWay}" Visibility="{x:Bind ViewModel.IllustratorViewModel.IsFollowed, Mode=OneWay}" Command="{x:Bind UnfollowCommand}"></AppBarButton>
+
+                            </CommandBar>
                         </StackPanel>
                     </StackPanel>
-                </Grid>
-            </userControls:IllustrationContainer.Header>
-            <userControls:IllustrationContainer.CommandBarElements>
-                <AppBarButton Width="48"
-                              Icon="Back"
-                              LabelPosition="Collapsed"
-                              Tapped="BackButton_OnTapped" />
-            </userControls:IllustrationContainer.CommandBarElements>
-        </userControls:IllustrationContainer>
-
-    </controls1:DockPanel>
+                </StackPanel>
+            </Grid>
+        </userControls:IllustrationContainer.Header>
+        <userControls:IllustrationContainer.CommandBarElements>
+            <AppBarButton Width="48"
+                          Icon="Back"
+                          LabelPosition="Collapsed"
+                          Tapped="BackButton_OnTapped" />
+        </userControls:IllustrationContainer.CommandBarElements>
+    </userControls:IllustrationContainer>
 </controls:EnhancedPage>

--- a/src/Pixeval/Pages/IllustratorViewer/IllustratorPageViewModel.cs
+++ b/src/Pixeval/Pages/IllustratorViewer/IllustratorPageViewModel.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Pixeval.Controls.IllustratorView;
+
+namespace Pixeval.Pages.IllustratorViewer;
+
+public sealed partial class IllustratorPageViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private IllustratorPageIllustratorModel? _illustratorViewModel;
+
+
+}

--- a/src/Pixeval/Pages/MainPage.xaml.cs
+++ b/src/Pixeval/Pages/MainPage.xaml.cs
@@ -71,7 +71,7 @@ public sealed partial class MainPage : ISupportCustomTitleBarDragRegion
     private static IllustrationViewModel? _illustrationViewerContent;
 
     // Similar to the previous field, this field contains a illustrator model
-    private static IllustratorViewModel? _illustratorViewerContent;
+    private static IllustratorPageIllustratorModel? _illustratorViewerContent;
 
     private readonly MainPageViewModel _viewModel = new();
 

--- a/src/Pixeval/UserControls/IllustrationContainer.xaml.cs
+++ b/src/Pixeval/UserControls/IllustrationContainer.xaml.cs
@@ -32,9 +32,16 @@ namespace Pixeval.UserControls;
 
 [DependencyProperty<ObservableCollection<ICommandBarElement>>("PrimaryCommandsSupplements", DefaultValue = "new ObservableCollection<ICommandBarElement>()")]
 [DependencyProperty<ObservableCollection<ICommandBarElement>>("SecondaryCommandsSupplements", DefaultValue = "new ObservableCollection<ICommandBarElement>()")]
-[DependencyProperty<object>("Header")]
+[DependencyProperty<object>("Header", "HeaderPropertyChangedCallback")]
 public sealed partial class IllustrationContainer
-{
+{ 
+    private static void HeaderPropertyChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var container = (IllustrationContainer)d;
+        container.IllustrationView.Header = e.NewValue;
+    }
+    
+
     public IllustrationContainer()
     {
         InitializeComponent();
@@ -57,12 +64,13 @@ public sealed partial class IllustrationContainer
                     throw new ArgumentOutOfRangeException();
             }
         };
+        
         IllustrationView = App.AppViewModel.AppSetting.IllustrationViewOption switch
         {
             IllustrationViewOption.Regular => new GridIllustrationView(),
             IllustrationViewOption.Justified => new JustifiedLayoutIllustrationView(),
             _ => throw new ArgumentOutOfRangeException()
-        }; 
+        };
         IllustrationContainerDockPanel.Children.Add(IllustrationView.SelfIllustrationView);
     }
 

--- a/src/Pixeval/UserControls/IllustrationView/IIllustrationView.cs
+++ b/src/Pixeval/UserControls/IllustrationView/IIllustrationView.cs
@@ -25,6 +25,8 @@ namespace Pixeval.UserControls.IllustrationView;
 
 public interface IIllustrationView
 { 
+    object Header { get; set; }
+
     FrameworkElement SelfIllustrationView { get; }
 
     IllustrationViewViewModel ViewModel { get; }

--- a/src/Pixeval/UserControls/IllustrationView/JustifiedLayoutIllustrationView.xaml
+++ b/src/Pixeval/UserControls/IllustrationView/JustifiedLayoutIllustrationView.xaml
@@ -17,6 +17,7 @@
 
     <Grid>
         <justifiedLayout:JustifiedListView x:Name="IllustrationJustifiedListView"
+                                           Header="{x:Bind Header, Mode=OneWay}"
                                            DesireRows="{x:Bind CalculateDesiresRows(ActualHeight), Mode=OneWay}"
                                            LoadMoreRequested="IllustrationJustifiedListView_OnLoadMoreRequested"
                                            RowBringingIntoView="IllustrationJustifiedListView_OnRowBringingIntoView">

--- a/src/Pixeval/UserControls/IllustrationView/JustifiedLayoutIllustrationView.xaml.cs
+++ b/src/Pixeval/UserControls/IllustrationView/JustifiedLayoutIllustrationView.xaml.cs
@@ -21,9 +21,11 @@ using Pixeval.Util.IO;
 using Pixeval.Util.Threading;
 using Pixeval.Util.UI;
 using Pixeval.Utilities;
+using WinUI3Utilities.Attributes;
 
 namespace Pixeval.UserControls.IllustrationView;
 
+[DependencyProperty<object>("Header")]
 public sealed partial class JustifiedLayoutIllustrationView : IIllustrationView
 {
     private static readonly ExponentialEase ImageSourceSetEasingFunction = new()

--- a/src/Pixeval/UserControls/IllustratorView/IllustratorViewModel.cs
+++ b/src/Pixeval/UserControls/IllustratorView/IllustratorViewModel.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.UI.Xaml.Input;
@@ -118,13 +119,15 @@ public partial class IllustratorViewModel : ObservableObject, IDisposable
 
     private async Task SetAvatarAsync()
     {
-        var avatar = UserDetail!.UserEntity?.ProfileImageUrls?.Medium?.Let(url => App.AppViewModel.MakoClient.DownloadBitmapImageResultAsync(url, 100)) ?? Task.FromResult(Result<ImageSource>.OfFailure());
+        var avatar = UserDetail!.UserEntity?.ProfileImageUrls?.Medium?.Let(url => App.AppViewModel.MakoClient.DownloadBitmapImageResultAsync(url, 100)) 
+                     ?? Task.FromResult(Result<ImageSource>.OfFailure(new HttpRequestException("UserDetail contains no medium profile image")));
         AvatarSource = await avatar.GetOrElseAsync(await AppContext.GetPixivNoProfileImageAsync());
     }
 
     private async Task SetBannerSourceAsync()
     {
-        var stream = await (UserDetail!.UserProfile?.BackgroundImageUrl?.Let(url => App.AppViewModel.MakoClient.GetMakoHttpClient(MakoApiKind.ImageApi).DownloadAsIRandomAccessStreamAsync(url)) ?? Task.FromResult(Result<IRandomAccessStream>.OfFailure()));
+        var stream = await (UserDetail!.UserProfile?.BackgroundImageUrl?.Let(url => App.AppViewModel.MakoClient.GetMakoHttpClient(MakoApiKind.ImageApi).DownloadAsIRandomAccessStreamAsync(url)) 
+                            ?? Task.FromResult(Result<IRandomAccessStream>.OfFailure(new HttpRequestException("UserDetail contains no background image"))));
 
         BannerSource = stream switch
         {

--- a/src/Pixeval/UserControls/JustifiedLayout/JustifiedListView.xaml
+++ b/src/Pixeval/UserControls/JustifiedLayout/JustifiedListView.xaml
@@ -13,6 +13,7 @@
     <ListView x:Name="ItemsListView"
               HorizontalAlignment="Stretch"
               VerticalAlignment="Stretch"
+              Header="{x:Bind Header, Mode=OneWay}"
               ScrollViewer.HorizontalScrollBarVisibility="Auto"
               ScrollViewer.HorizontalScrollMode="Auto"
               ScrollViewer.IsHorizontalRailEnabled="True"

--- a/src/Pixeval/UserControls/JustifiedLayout/JustifiedListView.xaml.cs
+++ b/src/Pixeval/UserControls/JustifiedLayout/JustifiedListView.xaml.cs
@@ -37,7 +37,8 @@ public record JustifiedListViewRowBinding(DataTemplate Template, ICollection<Jus
 // The computed layout may be wider than the actual container's width, use this property to tune the width, the actual computed layout width will be the [ContainerWidth - this property]
 [DependencyProperty<int>("ContainerWidthDeviationOffset", DefaultValue = "55")]
 [DependencyProperty<int>("DesireRows", DefaultValue = "4")] 
-[DependencyProperty<int>("Spacing", DefaultValue = "2")] 
+[DependencyProperty<int>("Spacing", DefaultValue = "2")]
+[DependencyProperty<object>("Header")]
 public sealed partial class JustifiedListView
 {
     // Help finding the corresponding item in outer grid, so that we can perform the connect animation


### PR DESCRIPTION
fix: IllustratorPage now renders properly
fix: new IllustratorView now links to IllustratorPage
refactor: IllustratorViewModel -> IllustratorPageIllustratorModel (it's a model for illustrator, not illustrator page)

BREAKING CHANGE: Result.OfFailure no longer accepts null cause parameter. Always pass an Exception to it.