### PR TITLE
Poker/feat/illustrationviewer

### DIFF
--- a/src/Pixeval/App.xaml
+++ b/src/Pixeval/App.xaml
@@ -17,6 +17,7 @@
             <x:Double x:Key="PixevalBaseFontSize">12</x:Double>
             <x:Double x:Key="PixevalSubscriptFontSize">11</x:Double>
             <x:Double x:Key="PixevalCaptionFontSize">10</x:Double>
+            <x:Double x:Key="CollapsedAppBarButtonWidth">45</x:Double>
             <!--  Gap between different entries  -->
             <Thickness x:Key="StackLayoutEntriesMargin">0,20,0,0</Thickness>
             <!--  Gap between the same entry's different component  -->

--- a/src/Pixeval/ISupportCustomTitleBarDragRegionTest.cs
+++ b/src/Pixeval/ISupportCustomTitleBarDragRegionTest.cs
@@ -1,0 +1,32 @@
+#region Copyright (c) Pixeval/Pixeval
+// GPL v3 License
+// 
+// Pixeval/Pixeval
+// Copyright (c) 2023 Pixeval/ISupportCustomTitleBarDragRegion.cs
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#endregion
+
+using WinUI3Utilities;
+
+namespace Pixeval;
+
+public interface ISupportCustomTitleBarDragRegionTest
+{
+    /// <summary>
+    /// Informs the bearer to refresh the drag region.
+    /// </summary>
+    /// <returns></returns>
+    DragZoneHelper.DragZoneInfo SetTitleBarDragRegion();
+}

--- a/src/Pixeval/Pages/IllustrationViewer/IllustrationViewerPage.xaml
+++ b/src/Pixeval/Pages/IllustrationViewer/IllustrationViewerPage.xaml
@@ -1,55 +1,64 @@
-﻿<controls1:EnhancedPage x:Class="Pixeval.Pages.IllustrationViewer.IllustrationViewerPage"
-                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                        xmlns:controls1="using:Pixeval.Controls"
-                        xmlns:core="using:Microsoft.Xaml.Interactions.Core"
-                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                        xmlns:illustrationView="using:Pixeval.UserControls.IllustrationView"
-                        xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
-                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                        xmlns:ui="using:Pixeval.Util.UI"
-                        Loaded="IllustrationViewerPage_OnLoaded"
-                        PointerMoved="IllustrationViewerPage_OnPointerMoved"
-                        SizeChanged="IllustrationViewerPage_OnSizeChanged"
-                        mc:Ignorable="d">
+<controls1:EnhancedPage
+    x:Class="Pixeval.Pages.IllustrationViewer.IllustrationViewerPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls1="using:Pixeval.Controls"
+    xmlns:core="using:Microsoft.Xaml.Interactions.Core"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:illustrationView="using:Pixeval.UserControls.IllustrationView"
+    xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="using:Pixeval.Util.UI"
+    KeyboardAcceleratorPlacementMode="Hidden"
+    Loaded="IllustrationViewerPage_OnLoaded"
+    PointerMoved="IllustrationViewerPage_OnPointerMoved"
+    SizeChanged="IllustrationViewerPage_OnSizeChanged"
+    mc:Ignorable="d">
     <Page.KeyboardAccelerators>
-        <KeyboardAccelerator Key="Escape"
-                             Invoked="ExitFullScreenKeyboardAccelerator_OnInvoked"
-                             Modifiers="None" />
+        <KeyboardAccelerator
+            Key="Escape"
+            Invoked="ExitFullScreenKeyboardAccelerator_OnInvoked"
+            Modifiers="None" />
     </Page.KeyboardAccelerators>
     <controls1:EnhancedPage.Resources>
         <ThemeShadow x:Name="PopupShadow" />
         <ThemeShadow x:Name="SidePanelShadow" />
-        <AcrylicBrush x:Name="BottomCommandSectionBackground"
-                      FallbackColor="{StaticResource SecondaryAccentColor}"
-                      TintColor="{StaticResource SecondaryAccentColor}"
-                      TintLuminosityOpacity="0.8"
-                      TintOpacity="0.8" />
+        <AcrylicBrush
+            x:Name="BottomCommandSectionBackground"
+            FallbackColor="{StaticResource SecondaryAccentColor}"
+            TintColor="{StaticResource SecondaryAccentColor}"
+            TintLuminosityOpacity="0.8"
+            TintOpacity="0.8" />
     </controls1:EnhancedPage.Resources>
-    <SplitView x:Name="IllustrationInfoAndCommentsSplitView"
-               DisplayMode="Overlay"
-               IsPaneOpen="{x:Bind _viewModel.IsInfoPaneOpen, Mode=TwoWay}"
-               OpenPaneLength="330"
-               PaneBackground="Transparent"
-               PaneClosed="IllustrationInfoAndCommentsSplitView_OnPaneClosed"
-               PaneOpened="IllustrationInfoAndCommentsSplitView_OnPaneOpened">
+    <SplitView
+        x:Name="IllustrationInfoAndCommentsSplitView"
+        DisplayMode="Overlay"
+        IsPaneOpen="{x:Bind _viewModel.IsInfoPaneOpen, Mode=TwoWay}"
+        OpenPaneLength="330"
+        PaneBackground="Transparent"
+        PaneClosed="IllustrationInfoAndCommentsSplitView_OnPaneClosed"
+        PaneOpened="IllustrationInfoAndCommentsSplitView_OnPaneOpened">
         <SplitView.Pane>
-            <Grid Width="330"
-                  HorizontalAlignment="Left"
-                  Background="Transparent">
-                <Grid Width="320"
-                      HorizontalAlignment="Left"
-                      Background="{StaticResource SystemControlBackgroundChromeMediumLowBrush}"
-                      Shadow="{x:Bind SidePanelShadow}"
-                      Translation="0,0,40">
-                    <NavigationView IsBackButtonVisible="Collapsed"
-                                    IsSettingsVisible="False"
-                                    PaneDisplayMode="Top"
-                                    SelectionChanged="IllustrationInfoAndCommentsNavigationView_OnSelectionChanged">
+            <Grid
+                Width="330"
+                HorizontalAlignment="Left"
+                Background="Transparent">
+                <Grid
+                    Width="320"
+                    HorizontalAlignment="Left"
+                    Background="{StaticResource SystemControlBackgroundChromeMediumLowBrush}"
+                    Shadow="{x:Bind SidePanelShadow}"
+                    Translation="0,0,40">
+                    <NavigationView
+                        IsBackButtonVisible="Collapsed"
+                        IsSettingsVisible="False"
+                        PaneDisplayMode="Top"
+                        SelectionChanged="IllustrationInfoAndCommentsNavigationView_OnSelectionChanged">
                         <NavigationView.MenuItems>
-                            <NavigationViewItem x:Uid="/IllustrationViewerPage/IllustrationInfoTab"
-                                                IsSelected="True"
-                                                Tag="{x:Bind _illustrationInfoTag}" />
+                            <NavigationViewItem
+                                x:Uid="/IllustrationViewerPage/IllustrationInfoTab"
+                                IsSelected="True"
+                                Tag="{x:Bind _illustrationInfoTag}" />
                             <NavigationViewItem x:Uid="/IllustrationViewerPage/CommentsTab" Tag="{x:Bind _commentsTag}" />
                             <NavigationViewItem x:Uid="/IllustrationViewerPage/RelatedWorksTab" Tag="{x:Bind _relatedWorksTag}" />
                         </NavigationView.MenuItems>
@@ -59,49 +68,52 @@
             </Grid>
         </SplitView.Pane>
         <Grid x:Name="IllustrationPresenterDockPanel" HorizontalAlignment="Stretch">
-            <Grid x:Name="TopCommandBar"
-                  HorizontalAlignment="Stretch"
-                  VerticalAlignment="Top">
-                <Image Width="25"
-                       Height="25"
-                       Margin="15,0,0,0"
-                       HorizontalAlignment="Left"
-                       Source="/Assets/Images/logo44x44.ico" />
+            <Grid
+                x:Name="TopCommandBar"
+                Height="48"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Top">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="150" />
+                </Grid.ColumnDefinitions>
+                <Image
+                    Grid.Column="0"
+                    Width="25"
+                    Height="25"
+                    Margin="12"
+                    HorizontalAlignment="Left"
+                    Source="/Assets/Images/logo44x44.ico" />
                 <!--  ReSharper disable once Xaml.PossibleNullReferenceException  -->
-                <TextBlock Margin="50,-1,0,0"
-                           VerticalAlignment="Center"
-                           FontSize="{StaticResource PixevalContentFontSize}"
-                           Text="{x:Bind _viewModel.IllustrationViewModelInTheGridView.Illustration.Title, Mode=OneWay}" />
-                <CommandBar x:Name="IllustrationViewerCommandBar"
-                            Width="300"
-                            Margin="0,0,20,0"
-                            HorizontalAlignment="Center"
-                            DefaultLabelPosition="Collapsed">
-                    <AppBarToggleButton x:Uid="/IllustrationViewerPage/IllustrationInfoAndCommentsButton"
-                                        Width="40"
-                                        Icon="{ui:FontIcon Glyph=InfoE946}"
-                                        IsChecked="{x:Bind _viewModel.IsInfoPaneOpen, Mode=TwoWay}">
-                        <AppBarToggleButton.KeyboardAccelerators>
-                            <KeyboardAccelerator Key="F12" />
-                        </AppBarToggleButton.KeyboardAccelerators>
-                    </AppBarToggleButton>
-                    <AppBarButton Width="40"
-                                  Command="{x:Bind _viewModel.PlayGifCommand}"
-                                  Visibility="{x:Bind _viewModel.IsUgoira}" />
+                <TextBlock
+                    Grid.Column="1"
+                    MaxWidth="200"
+                    VerticalAlignment="Center"
+                    FontSize="{StaticResource PixevalContentFontSize}"
+                    Text="{x:Bind _viewModel.IllustrationViewModelInTheGridView.Illustration.Title, Mode=OneWay}"
+                    TextTrimming="CharacterEllipsis" />
+                <CommandBar
+                    x:Name="IllustrationViewerCommandBar"
+                    Grid.Column="2"
+                    HorizontalAlignment="Center"
+                    DefaultLabelPosition="Collapsed">
+                    <AppBarToggleButton
+                        Command="{x:Bind _viewModel.IllustrationInfoAndCommentsCommand}"
+                        IsChecked="{x:Bind _viewModel.IsInfoPaneOpen, Mode=TwoWay}"
+                        SizeChanged="CommandBarElementOnSizeChanged" />
+                    <AppBarButton
+                        Command="{x:Bind _viewModel.PlayGifCommand}"
+                        SizeChanged="CommandBarElementOnSizeChanged"
+                        Visibility="{x:Bind _viewModel.IsUgoira}" />
                     <AppBarSeparator />
-                    <AppBarButton x:Uid="/IllustrationViewerPage/CopyButton"
-                                  Width="40"
-                                  Command="{x:Bind _viewModel.CopyCommand}" />
-                    <AppBarButton x:Uid="/IllustrationViewerPage/SaveButton"
-                                  Width="40"
-                                  Command="{x:Bind _viewModel.SaveCommand}" />
-                    <AppBarButton x:Uid="/IllustrationViewerPage/SaveAsButton"
-                                  Width="40"
-                                  Command="{x:Bind _viewModel.SaveAsCommand}" />
+                    <AppBarButton Command="{x:Bind _viewModel.CopyCommand}" SizeChanged="CommandBarElementOnSizeChanged" />
+                    <AppBarButton Command="{x:Bind _viewModel.SaveCommand}" SizeChanged="CommandBarElementOnSizeChanged" />
+                    <AppBarButton Command="{x:Bind _viewModel.SaveAsCommand}" SizeChanged="CommandBarElementOnSizeChanged" />
                     <AppBarSeparator />
-                    <AppBarButton x:Uid="/IllustrationViewerPage/SetAsButton"
-                                  Width="40"
-                                  Icon="{ui:FontIcon Glyph=PersonalizeE771}">
+                    <AppBarButton Command="{x:Bind _viewModel.SetAsCommand}" SizeChanged="CommandBarElementOnSizeChanged">
                         <AppBarButton.Flyout>
                             <MenuFlyout>
                                 <MenuFlyoutItem Command="{x:Bind _viewModel.SetAsBackgroundCommand}" />
@@ -110,182 +122,208 @@
                         </AppBarButton.Flyout>
                     </AppBarButton>
                     <AppBarSeparator />
-                    <AppBarButton x:Uid="/IllustrationViewerPage/AddToBookmarkButton" Command="{x:Bind _viewModel.AddToBookmarkCommand}" />
-                    <AppBarButton x:Name="GenerateLinkToThisPageButton"
-                                  x:Uid="/IllustrationViewerPage/GenerateLinkToThisPageButton"
-                                  Command="{x:Bind _viewModel.GenerateLinkCommand}" />
-                    <AppBarButton x:Uid="/IllustrationViewerPage/GenerateWebLinkButton" Command="{x:Bind _viewModel.GenerateWebLinkCommand}" />
-                    <AppBarButton x:Uid="/IllustrationViewerPage/OpenInWebBrowserButton" Command="{x:Bind _viewModel.OpenInWebBrowserCommand}" />
-                    <AppBarButton x:Uid="/IllustrationViewerPage/ShowQrCodeButton" Command="{x:Bind _viewModel.ShowQrCodeCommand}" />
-                    <AppBarButton x:Uid="/IllustrationViewerPage/ShareButton" Command="{x:Bind _viewModel.ShareCommand}" />
+                    <AppBarButton Command="{x:Bind _viewModel.AddToBookmarkCommand}" SizeChanged="CommandBarElementOnSizeChanged" />
+                    <AppBarButton
+                        Command="{x:Bind _viewModel.GenerateLinkCommand}"
+                        SizeChanged="CommandBarElementOnSizeChanged"
+                        Tapped="GenerateLinkCommandOnTapped" />
+                    <AppBarButton Command="{x:Bind _viewModel.GenerateWebLinkCommand}" SizeChanged="CommandBarElementOnSizeChanged" />
+                    <AppBarButton Command="{x:Bind _viewModel.OpenInWebBrowserCommand}" SizeChanged="CommandBarElementOnSizeChanged" />
+                    <AppBarButton
+                        Command="{x:Bind _viewModel.ShowQrCodeCommand}"
+                        SizeChanged="CommandBarElementOnSizeChanged"
+                        Tapped="ShowQrCodeOnTapped" />
+                    <AppBarButton Command="{x:Bind _viewModel.ShareCommand}" SizeChanged="CommandBarElementOnSizeChanged" />
                 </CommandBar>
-                <StackPanel Margin="0,0,150,0"
-                            HorizontalAlignment="Right"
-                            VerticalAlignment="Center"
-                            Orientation="Horizontal">
-                    <CommandBar x:Name="IllustrationViewerSubCommandBar"
-                                HorizontalAlignment="Right"
-                                VerticalAlignment="Center"
-                                DefaultLabelPosition="Collapsed">
-                        <AppBarToggleButton x:Uid="/IllustrationViewerPage/FullScreenButton"
-                                            Width="40"
-                                            Command="{x:Bind _viewModel.FullScreenCommand}"
-                                            Tapped="FullScreenButton_OnTapped" />
-                        <AppBarToggleButton x:Name="RestoreResolutionToggleButton"
-                                            Width="40"
-                                            Command="{x:Bind _viewModel.RestoreResolutionCommand}"
-                                            Tapped="RestoreResolutionToggleButton_OnTapped" />
-                        <AppBarButton x:Uid="/IllustrationViewerPage/ZoomOutButton"
-                                      Width="40"
-                                      Command="{x:Bind _viewModel.ZoomOutCommand}" />
-                        <AppBarButton x:Uid="/IllustrationViewerPage/ZoomInButton"
-                                      Width="40"
-                                      Command="{x:Bind _viewModel.ZoomInCommand}" />
+                <StackPanel
+                    Grid.Column="3"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    Orientation="Horizontal">
+                    <CommandBar
+                        x:Name="IllustrationViewerSubCommandBar"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Center"
+                        DefaultLabelPosition="Collapsed">
+                        <AppBarToggleButton
+                            Width="{StaticResource CollapsedAppBarButtonWidth}"
+                            Command="{x:Bind _viewModel.FullScreenCommand}"
+                            Tapped="FullScreenButton_OnTapped" />
+                        <AppBarToggleButton
+                            x:Name="RestoreResolutionToggleButton"
+                            Width="{StaticResource CollapsedAppBarButtonWidth}"
+                            Command="{x:Bind _viewModel.RestoreResolutionCommand}"
+                            Tapped="RestoreResolutionToggleButton_OnTapped" />
+                        <AppBarButton Width="{StaticResource CollapsedAppBarButtonWidth}" Command="{x:Bind _viewModel.ZoomOutCommand}" />
+                        <AppBarButton Width="{StaticResource CollapsedAppBarButtonWidth}" Command="{x:Bind _viewModel.ZoomInCommand}" />
                     </CommandBar>
-                    <TextBlock x:Name="CurrentScalePercentage"
-                               Width="50"
-                               Margin="-5,-3,0,0"
-                               VerticalAlignment="Center"
-                               FontSize="{StaticResource PixevalContentFontSize}"
-                               FontWeight="SemiBold"
-                               HorizontalTextAlignment="Center"
-                               Loaded="CurrentScalePercentage_OnLoaded"
-                               TextAlignment="Center" />
+                    <TextBlock
+                        x:Name="CurrentScalePercentage"
+                        Width="50"
+                        Margin="-5,-3,0,0"
+                        VerticalAlignment="Center"
+                        FontSize="{StaticResource PixevalContentFontSize}"
+                        FontWeight="SemiBold"
+                        HorizontalTextAlignment="Center"
+                        Loaded="CurrentScalePercentage_OnLoaded"
+                        TextAlignment="Center" />
                 </StackPanel>
+                <TeachingTip
+                    x:Name="QrCodeTeachingTip"
+                    x:Uid="/IllustrationViewerPage/QrCodeTeachingTip"
+                    Title="保存二维码"
+                    Grid.Column="0"
+                    IsLightDismissEnabled="True" />
             </Grid>
 
-            <TeachingTip x:Uid="/IllustrationViewerPage/GenerateLinkToThisPageButtonTeachingTip"
-                         ActionButtonClick="GenerateLinkToThisPageButtonTeachingTip_OnActionButtonClick"
-                         IsOpen="{x:Bind _viewModel.IsGenerateLinkTeachingTipOpen, Mode=OneWay}"
-                         Target="{x:Bind GenerateLinkToThisPageButton}">
+            <TeachingTip
+                x:Name="GenerateLinkToThisPageButtonTeachingTip"
+                x:Uid="/IllustrationViewerPage/GenerateLinkToThisPageButtonTeachingTip"
+                ActionButtonClick="GenerateLinkToThisPageButtonTeachingTip_OnActionButtonClick">
                 <TeachingTip.HeroContent>
                     <Image Source="../../Assets/Images/illust-app-link-sample.png" />
                 </TeachingTip.HeroContent>
             </TeachingTip>
-            <Frame x:Name="IllustrationImageShowcaseFrame"
-                   Tapped="IllustrationImageShowcaseFrame_OnTapped"
-                   Margin="0,48,0,0"
-                   HorizontalAlignment="Stretch"
-                   VerticalAlignment="Stretch" />
+            <Frame
+                x:Name="IllustrationImageShowcaseFrame"
+                Margin="0,48,0,0"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Stretch"
+                Tapped="IllustrationImageShowcaseFrame_OnTapped" />
 
-            <Grid Width="80"
-                  Margin="0,48,0,0"
-                  HorizontalAlignment="Left"
-                  VerticalAlignment="Stretch"
-                  Background="Transparent"
-                  CornerRadius="5"
-                  PointerEntered="LeftPageButtonArea_OnPointerEntered"
-                  PointerExited="LeftPageButtonArea_OnPointerExited">
-                <Grid x:Name="PrevButtonDetector"
-                      HorizontalAlignment="Stretch"
-                      VerticalAlignment="Stretch"
-                      Background="Transparent"
-                      Opacity="0">
+            <Grid
+                Width="80"
+                Margin="0,48,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Stretch"
+                Background="Transparent"
+                CornerRadius="5"
+                PointerEntered="LeftPageButtonArea_OnPointerEntered"
+                PointerExited="LeftPageButtonArea_OnPointerExited">
+                <Grid
+                    x:Name="PrevButtonDetector"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Background="Transparent"
+                    Opacity="0">
                     <Grid.OpacityTransition>
                         <ScalarTransition Duration="0:0:0.300" />
                     </Grid.OpacityTransition>
-                    <Grid Width="30"
-                          Height="100"
-                          VerticalAlignment="Center"
-                          Background="{StaticResource SecondaryAccentBrush}"
-                          CornerRadius="5" />
-                    <ContentControl Width="20"
-                                    Height="100"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    Content="{ui:FontIcon Glyph=ChevronLeft20F743}"
-                                    Tapped="PrevImageAppBarButton_OnTapped"
-                                    Visibility="{x:Bind _viewModel.CalculatePrevImageButtonVisibility(_viewModel.CurrentIndex), Mode=OneWay}" />
-                    <ContentControl Width="20"
-                                    Height="100"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    Content="{ui:FontIcon Glyph=ChevronLeft20F743}"
-                                    Tapped="PrevIllustrationAppBarButton_OnTapped"
-                                    Visibility="{x:Bind _viewModel.CalculatePrevIllustrationButtonVisibility(_viewModel.CurrentIndex), Mode=OneWay}" />
+                    <Grid
+                        Width="30"
+                        Height="100"
+                        VerticalAlignment="Center"
+                        Background="{StaticResource SecondaryAccentBrush}"
+                        CornerRadius="5" />
+                    <ContentControl
+                        Width="20"
+                        Height="100"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        HorizontalContentAlignment="Center"
+                        VerticalContentAlignment="Center"
+                        Content="{ui:FontIcon Glyph=ChevronLeft20F743}"
+                        Tapped="PrevImageAppBarButton_OnTapped"
+                        Visibility="{x:Bind _viewModel.CalculatePrevImageButtonVisibility(_viewModel.CurrentIndex), Mode=OneWay}" />
+                    <ContentControl
+                        Width="20"
+                        Height="100"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        HorizontalContentAlignment="Center"
+                        VerticalContentAlignment="Center"
+                        Content="{ui:FontIcon Glyph=ChevronLeft20F743}"
+                        Tapped="PrevIllustrationAppBarButton_OnTapped"
+                        Visibility="{x:Bind _viewModel.CalculatePrevIllustrationButtonVisibility(_viewModel.CurrentIndex), Mode=OneWay}" />
                 </Grid>
             </Grid>
-            <Grid Width="80"
-                  Margin="0,48,0,0"
-                  HorizontalAlignment="Right"
-                  VerticalAlignment="Stretch"
-                  Background="Transparent"
-                  CornerRadius="5"
-                  PointerEntered="RightPageButtonArea_OnPointerEntered"
-                  PointerExited="RightPageButtonArea_OnPointerExited">
-                <Grid x:Name="NextButtonDetector"
-                      HorizontalAlignment="Stretch"
-                      VerticalAlignment="Stretch"
-                      Background="Transparent"
-                      Opacity="0">
+            <Grid
+                Width="80"
+                Margin="0,48,0,0"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Stretch"
+                Background="Transparent"
+                CornerRadius="5"
+                PointerEntered="RightPageButtonArea_OnPointerEntered"
+                PointerExited="RightPageButtonArea_OnPointerExited">
+                <Grid
+                    x:Name="NextButtonDetector"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    Background="Transparent"
+                    Opacity="0">
                     <Grid.OpacityTransition>
                         <ScalarTransition Duration="0:0:0.300" />
                     </Grid.OpacityTransition>
-                    <Grid Width="30"
-                          Height="100"
-                          VerticalAlignment="Center"
-                          Background="{StaticResource SecondaryAccentBrush}"
-                          CornerRadius="5" />
-                    <ContentControl Width="20"
-                                    Height="100"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    Content="{ui:FontIcon Glyph=ChevronRight20F745}"
-                                    Tapped="NextImageAppBarButton_OnTapped"
-                                    Visibility="{x:Bind _viewModel.CalculateNextImageButtonVisibility(_viewModel.CurrentIndex), Mode=OneWay}" />
-                    <ContentControl Width="20"
-                                    Height="100"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    Content="{ui:FontIcon Glyph=ChevronRight20F745}"
-                                    Tapped="NextIllustrationAppBarButton_OnTapped"
-                                    Visibility="{x:Bind _viewModel.CalculateNextIllustrationButtonVisibility(_viewModel.CurrentIndex), Mode=OneWay}" />
+                    <Grid
+                        Width="30"
+                        Height="100"
+                        VerticalAlignment="Center"
+                        Background="{StaticResource SecondaryAccentBrush}"
+                        CornerRadius="5" />
+                    <ContentControl
+                        Width="20"
+                        Height="100"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        HorizontalContentAlignment="Center"
+                        VerticalContentAlignment="Center"
+                        Content="{ui:FontIcon Glyph=ChevronRight20F745}"
+                        Tapped="NextImageAppBarButton_OnTapped"
+                        Visibility="{x:Bind _viewModel.CalculateNextImageButtonVisibility(_viewModel.CurrentIndex), Mode=OneWay}" />
+                    <ContentControl
+                        Width="20"
+                        Height="100"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        HorizontalContentAlignment="Center"
+                        VerticalContentAlignment="Center"
+                        Content="{ui:FontIcon Glyph=ChevronRight20F745}"
+                        Tapped="NextIllustrationAppBarButton_OnTapped"
+                        Visibility="{x:Bind _viewModel.CalculateNextIllustrationButtonVisibility(_viewModel.CurrentIndex), Mode=OneWay}" />
                 </Grid>
             </Grid>
 
             <!--  工具栏的识别区  -->
-            <StackPanel x:Name="BottomCommandSection"
-                        Margin="0,0,0,20"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Bottom"
-                        Spacing="10">
+            <StackPanel
+                x:Name="BottomCommandSection"
+                Margin="0,0,0,20"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Bottom"
+                Spacing="10">
                 <StackPanel.TranslationTransition>
                     <Vector3Transition Duration="0:0:0.300" />
                 </StackPanel.TranslationTransition>
                 <Grid Margin="0,0,0,10" HorizontalAlignment="Center">
-                    <Rectangle Width="400"
-                               Height="100"
-                               Fill="Transparent"
-                               Opacity="0">
+                    <Rectangle
+                        Width="400"
+                        Height="100"
+                        Fill="Transparent"
+                        Opacity="0">
                         <interactivity:Interaction.Behaviors>
                             <core:EventTriggerBehavior EventName="PointerEntered">
-                                <core:ChangePropertyAction PropertyName="Opacity"
-                                                           TargetObject="{x:Bind CommandBorder}"
-                                                           Value="0.7" />
+                                <core:ChangePropertyAction
+                                    PropertyName="Opacity"
+                                    TargetObject="{x:Bind CommandBorder}"
+                                    Value="0.7" />
                             </core:EventTriggerBehavior>
                             <core:EventTriggerBehavior EventName="PointerExited">
-                                <core:ChangePropertyAction PropertyName="Opacity"
-                                                           TargetObject="{x:Bind CommandBorder}"
-                                                           Value="0" />
+                                <core:ChangePropertyAction
+                                    PropertyName="Opacity"
+                                    TargetObject="{x:Bind CommandBorder}"
+                                    Value="0" />
                             </core:EventTriggerBehavior>
                         </interactivity:Interaction.Behaviors>
                     </Rectangle>
-                    <Border x:Name="CommandBorder"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            BorderBrush="{StaticResource SecondaryAccentBorderBrush}"
-                            BorderThickness="0.5"
-                            CornerRadius="10"
-                            Opacity="0"
-                            Translation="0,0,30">
+                    <Border
+                        x:Name="CommandBorder"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        BorderBrush="{StaticResource SecondaryAccentBorderBrush}"
+                        BorderThickness="0.5"
+                        CornerRadius="10"
+                        Opacity="0"
+                        Translation="0,0,30">
                         <Border.Shadow>
                             <ThemeShadow x:Name="CommandBorderDropShadow" />
                         </Border.Shadow>
@@ -294,57 +332,65 @@
                                 <core:ChangePropertyAction PropertyName="Opacity" Value="1" />
                             </core:EventTriggerBehavior>
                             <core:EventTriggerBehavior EventName="PointerExited">
-                                <core:ChangePropertyAction PropertyName="Opacity"
-                                                           TargetObject="{x:Bind CommandBorder}"
-                                                           Value="0.7" />
+                                <core:ChangePropertyAction
+                                    PropertyName="Opacity"
+                                    TargetObject="{x:Bind CommandBorder}"
+                                    Value="0.7" />
                             </core:EventTriggerBehavior>
                         </interactivity:Interaction.Behaviors>
                         <Border.OpacityTransition>
                             <ScalarTransition />
                         </Border.OpacityTransition>
-                        <CommandBar Background="{StaticResource BottomCommandSectionBackground}"
-                                    CornerRadius="10"
-                                    DefaultLabelPosition="Collapsed"
-                                    OverflowButtonVisibility="Collapsed">
-                            <AppBarButton x:Uid="/IllustrationViewerPage/BookmarkButton"
-                                          Width="50"
-                                          Command="{x:Bind _viewModel.Current.IllustrationViewerPageViewModel.BookmarkCommand}" />
-                            <AppBarButton x:Uid="/IllustrationViewerPage/ZoomInButton"
-                                          Width="50"
-                                          Command="{x:Bind _viewModel.Current.IllustrationViewerPageViewModel.ZoomInCommand}" />
-                            <AppBarButton x:Uid="/IllustrationViewerPage/ZoomOutButton"
-                                          Width="50"
-                                          Command="{x:Bind _viewModel.Current.IllustrationViewerPageViewModel.ZoomOutCommand}" />
-                            <AppBarButton x:Uid="/IllustrationViewerPage/SaveCurrentImageButton"
-                                          Width="50"
-                                          Command="{x:Bind _viewModel.Current.IllustrationViewerPageViewModel.SaveCommand}" />
+                        <CommandBar
+                            Background="{StaticResource BottomCommandSectionBackground}"
+                            CornerRadius="10"
+                            DefaultLabelPosition="Collapsed"
+                            OverflowButtonVisibility="Collapsed">
+                            <AppBarButton
+                                x:Uid="/IllustrationViewerPage/BookmarkButton"
+                                Width="50"
+                                Command="{x:Bind _viewModel.Current.IllustrationViewerPageViewModel.BookmarkCommand}" />
+                            <AppBarButton
+                                x:Uid="/IllustrationViewerPage/ZoomInButton"
+                                Width="50"
+                                Command="{x:Bind _viewModel.Current.IllustrationViewerPageViewModel.ZoomInCommand}" />
+                            <AppBarButton
+                                x:Uid="/IllustrationViewerPage/ZoomOutButton"
+                                Width="50"
+                                Command="{x:Bind _viewModel.Current.IllustrationViewerPageViewModel.ZoomOutCommand}" />
+                            <AppBarButton
+                                x:Uid="/IllustrationViewerPage/SaveCurrentImageButton"
+                                Width="50"
+                                Command="{x:Bind _viewModel.Current.IllustrationViewerPageViewModel.SaveCommand}" />
                         </CommandBar>
                     </Border>
                 </Grid>
-                <Grid Height="98"
-                      Margin="150,0"
-                      Padding="0,3"
-                      HorizontalAlignment="Center"
-                      Background="{StaticResource BottomCommandSectionBackground}"
-                      BorderBrush="{StaticResource SecondaryAccentBorderBrush}"
-                      BorderThickness="0.5"
-                      CornerRadius="15"
-                      Translation="0,0,30">
+                <Grid
+                    Height="98"
+                    Margin="150,0"
+                    Padding="0,3"
+                    HorizontalAlignment="Center"
+                    Background="{StaticResource BottomCommandSectionBackground}"
+                    BorderBrush="{StaticResource SecondaryAccentBorderBrush}"
+                    BorderThickness="0.5"
+                    CornerRadius="15"
+                    Translation="0,0,30">
                     <Grid.Shadow>
                         <ThemeShadow x:Name="ThumbnailListDropShadow" />
                     </Grid.Shadow>
-                    <ListView x:Name="ThumbnailList"
-                              Margin="5"
-                              Padding="0"
-                              HorizontalAlignment="Stretch"
-                              VerticalAlignment="Stretch"
-                              IsMultiSelectCheckBoxEnabled="False"
-                              ItemsSource="{x:Bind _viewModel.Snapshot, Mode=OneWay}"
-                              ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                              ScrollViewer.HorizontalScrollMode="Auto"
-                              ScrollViewer.IsHorizontalRailEnabled="True"
-                              SelectionChanged="ThumbnailList_OnSelectionChanged"
-                              SelectionMode="Single">
+                    <ListView
+                        x:Name="ThumbnailList"
+                        Margin="5"
+                        Padding="0"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
+                        IsMultiSelectCheckBoxEnabled="False"
+                        ItemsSource="{x:Bind _viewModel.Snapshot, Mode=OneWay}"
+                        ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                        ScrollViewer.HorizontalScrollMode="Auto"
+                        ScrollViewer.IsHorizontalRailEnabled="True"
+                        SelectionChanged="ThumbnailList_OnSelectionChanged"
+                        SelectionMode="Single">
                         <ListView.ItemContainerStyle>
                             <Style BasedOn="{StaticResource ListViewItemStretchStyle}" TargetType="ListViewItem">
                                 <Setter Property="VerticalAlignment" Value="Stretch" />
@@ -358,20 +404,22 @@
                         <ListView.ItemTemplate>
                             <DataTemplate x:DataType="illustrationView:IllustrationViewModel">
                                 <Grid Width="80" Height="80">
-                                    <Border Width="78"
-                                            Height="78"
-                                            CornerRadius="5"
-                                            Loaded="ThumbnailBorder_OnLoaded">
+                                    <Border
+                                        Width="78"
+                                        Height="78"
+                                        CornerRadius="5"
+                                        Loaded="ThumbnailBorder_OnLoaded">
                                         <Border.Background>
                                             <ImageBrush ImageSource="{x:Bind ThumbnailSource, Mode=OneWay}" Stretch="UniformToFill" />
                                         </Border.Background>
                                     </Border>
-                                    <Border x:Name="ThumbnailBorder"
-                                            Width="80"
-                                            Height="80"
-                                            BorderBrush="{StaticResource SystemControlHighlightAccentBrush}"
-                                            CornerRadius="5"
-                                            EffectiveViewportChanged="ThumbnailList_OnEffectiveViewportChanged" />
+                                    <Border
+                                        x:Name="ThumbnailBorder"
+                                        Width="80"
+                                        Height="80"
+                                        BorderBrush="{StaticResource SystemControlHighlightAccentBrush}"
+                                        CornerRadius="5"
+                                        EffectiveViewportChanged="ThumbnailList_OnEffectiveViewportChanged" />
                                 </Grid>
                             </DataTemplate>
                         </ListView.ItemTemplate>

--- a/src/Pixeval/Pages/IllustrationViewer/IllustrationViewerPageViewModel.cs
+++ b/src/Pixeval/Pages/IllustrationViewer/IllustrationViewerPageViewModel.cs
@@ -23,6 +23,8 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using Windows.Storage.Streams;
 using Windows.System;
 using Windows.System.UserProfile;
 using Microsoft.Extensions.DependencyInjection;
@@ -58,15 +60,10 @@ public partial class IllustrationViewerPageViewModel : ObservableObject, IDispos
     private int _currentIndex;
 
     [ObservableProperty]
-    private bool _isGenerateLinkTeachingTipOpen;
-
-    [ObservableProperty]
     private bool _isInfoPaneOpen;
 
     [ObservableProperty]
     private IllustrationViewModel? _selectedIllustrationViewModel;
-
-    private ImageSource? _qrCodeSource;
 
     // The reason why we don't put UserProfileImageSource into IllustrationViewModel
     // is because the whole array of Illustrations is just representing the same 
@@ -191,27 +188,19 @@ public partial class IllustrationViewerPageViewModel : ObservableObject, IDispos
         RestoreResolutionCommand.Label = scaled ? IllustrationViewerPageResources.UniformToFillResolution : IllustrationViewerPageResources.RestoreOriginalResolution;
         RestoreResolutionCommand.IconSource = scaled ? FontIconSymbols.Webcam2E960.GetFontIconSource() : FontIconSymbols.WebcamE8B8.GetFontIconSource();
     }
-    
+
     private void InitializeCommands()
     {
-        BookmarkCommand = new XamlUICommand
-        {
-            KeyboardAccelerators =
-            {
-                new KeyboardAccelerator
-                {
-                    Modifiers = VirtualKeyModifiers.Control,
-                    Key = VirtualKey.D
-                }
-            },
-            Label = FirstIllustrationViewModel!.IsBookmarked ? MiscResources.RemoveBookmark : MiscResources.AddBookmark,
-            IconSource = MakoHelper.GetBookmarkButtonIconSource(FirstIllustrationViewModel.IsBookmarked)
-        };
+        BookmarkCommand =
+            (FirstIllustrationViewModel!.IsBookmarked ? MiscResources.RemoveBookmark : MiscResources.AddBookmark)
+            .GetCommand(
+                MakoHelper.GetBookmarkButtonIconSource(FirstIllustrationViewModel.IsBookmarked),
+                VirtualKeyModifiers.Control, VirtualKey.D);
 
         FullScreenCommand.CanExecuteRequested += LoadingCompletedCanExecuteRequested;
-        
+
         RestoreResolutionCommand.CanExecuteRequested += LoadingCompletedCanExecuteRequested;
-        
+
         BookmarkCommand.ExecuteRequested += BookmarkCommandOnExecuteRequested;
 
         CopyCommand.CanExecuteRequested += LoadingCompletedCanExecuteRequested;
@@ -229,11 +218,9 @@ public partial class IllustrationViewerPageViewModel : ObservableObject, IDispos
         SaveCommand.ExecuteRequested += SaveCommandOnExecuteRequested;
         SaveAsCommand.ExecuteRequested += SaveAsCommandOnExecuteRequested;
 
-        GenerateLinkCommand.ExecuteRequested += GenerateLinkCommandOnExecuteRequested;
         GenerateWebLinkCommand.ExecuteRequested += GenerateWebLinkCommandOnExecuteRequested;
         OpenInWebBrowserCommand.ExecuteRequested += OpenInWebBrowserCommandOnExecuteRequested;
         ShareCommand.ExecuteRequested += ShareCommandOnExecuteRequested;
-        ShowQrCodeCommand.ExecuteRequested += ShowQrCodeCommandOnExecuteRequested;
 
         SetAsLockScreenCommand.CanExecuteRequested += SetAsLockScreenCommandOnCanExecuteRequested;
         SetAsLockScreenCommand.ExecuteRequested += SetAsLockScreenCommandOnExecuteRequested;
@@ -309,13 +296,6 @@ public partial class IllustrationViewerPageViewModel : ObservableObject, IDispos
         args.CanExecute = !IsUgoira && Current.LoadingCompletedSuccessfully;
     }
 
-    private async void ShowQrCodeCommandOnExecuteRequested(XamlUICommand sender, ExecuteRequestedEventArgs args)
-    {
-        _qrCodeSource ??= await UIHelper.GenerateQrCodeForUrlAsync(MakoHelper.GenerateIllustrationWebUri(Current.IllustrationViewModel.Id).ToString());
-
-        PopupManager.ShowPopup(PopupManager.CreatePopup(new QrCodePresenter(_qrCodeSource), lightDismiss: true));
-    }
-
     private async void ShareCommandOnExecuteRequested(XamlUICommand sender, ExecuteRequestedEventArgs args)
     {
         if (Current.LoadingOriginalSourceTask is not { IsCompletedSuccessfully: true })
@@ -338,16 +318,6 @@ public partial class IllustrationViewerPageViewModel : ObservableObject, IDispos
         var link = MakoHelper.GenerateIllustrationWebUri(Current.IllustrationViewModel.Id).ToString();
         UIHelper.SetClipboardContent(package => package.SetText(link));
         SnackBarController.ShowSnack(IllustrationViewerPageResources.WebLinkCopiedToClipboardToastTitle, SnackBarController.SnackBarDurationLong);
-    }
-
-    private void GenerateLinkCommandOnExecuteRequested(XamlUICommand sender, ExecuteRequestedEventArgs args)
-    {
-        if (App.AppViewModel.AppSetting.DisplayTeachingTipWhenGeneratingAppLink)
-        {
-            IsGenerateLinkTeachingTipOpen = true;
-        }
-
-        UIHelper.SetClipboardContent(package => package.SetText(MakoHelper.GenerateIllustrationAppUri(Current.IllustrationViewModel.Id).ToString()));
     }
 
     private async void SaveAsCommandOnExecuteRequested(XamlUICommand sender, ExecuteRequestedEventArgs args)
@@ -379,31 +349,34 @@ public partial class IllustrationViewerPageViewModel : ObservableObject, IDispos
         if (bitmap.IsPlaying)
         {
             bitmap.Stop();
-            PlayGifCommand.Label = IllustrationViewerPageResources.PlayGif;
-            PlayGifCommand.IconSource = new SymbolIconSource
-            {
-                Symbol = Symbol.Play
-            };
+            PlayGifCommand.Description = PlayGifCommand.Label = IllustrationViewerPageResources.PlayGif;
+            PlayGifCommand.IconSource = new SymbolIconSource { Symbol = Symbol.Play };
         }
         else
         {
             bitmap.Play();
-            PlayGifCommand.Label = IllustrationViewerPageResources.PauseGif;
-            PlayGifCommand.IconSource = new SymbolIconSource
-            {
-                Symbol = Symbol.Stop
-            };
+            PlayGifCommand.Description = PlayGifCommand.Label = IllustrationViewerPageResources.PauseGif;
+            PlayGifCommand.IconSource = new SymbolIconSource { Symbol = Symbol.Stop };
         }
     }
 
-    private async void CopyCommandOnExecuteRequested(XamlUICommand sender, ExecuteRequestedEventArgs args)
+    private async void CopyCommandOnExecuteRequested(XamlUICommand sender, ExecuteRequestedEventArgs e)
     {
+        //UIHelper.SetClipboardContent(package =>
+        //{
+        //    //todo package.RequestedOperation = DataPackageOperation.Copy;
+        //    Current.OriginalImageStream!.Seek(0);
+        //    var stream = Current.OriginalImageStream.EncodeBitmapStreamAsync(false).GetAwaiter().GetResult(); 
+        //    var streamRef = RandomAccessStreamReference.CreateFromStream(stream);
+        //    package.SetBitmap(streamRef);
+        //});
         await UIHelper.SetClipboardContentAsync(async package =>
         {
             package.RequestedOperation = DataPackageOperation.Copy;
             var file = await AppKnownFolders.CreateTemporaryFileWithNameAsync(GetCopyContentFileName(), IsUgoira ? "gif" : "png");
             await Current.OriginalImageStream!.SaveToFileAsync(file);
-            package.SetStorageItems(Enumerates.ArrayOf(file), true);
+            var streamRef = RandomAccessStreamReference.CreateFromFile(file);
+            package.SetBitmap(streamRef);
         });
 
         string GetCopyContentFileName()
@@ -480,121 +453,50 @@ public partial class IllustrationViewerPageViewModel : ObservableObject, IDispos
 
     #region Commands
 
-    public StandardUICommand CopyCommand { get; } = new(StandardUICommandKind.Copy);
+    public XamlUICommand IllustrationInfoAndCommentsCommand { get; } =
+        IllustrationViewerPageResources.IllustrationInfoAndComments.GetCommand(FontIconSymbols.InfoE946, VirtualKey.F12);
 
-    public StandardUICommand PlayGifCommand { get; } = new(StandardUICommandKind.Play)
-    {
-        // The gif will be played as soon as its loaded, so the default state is playing and thus we need the button to be pause
-        Label = IllustrationViewerPageResources.PauseGif,
-        IconSource = new SymbolIconSource
-        {
-            Symbol = Symbol.Stop
-        }
-    };
+    public XamlUICommand CopyCommand { get; } = IllustrationViewerPageResources.Copy.GetCommand(
+            FontIconSymbols.CopyE8C8, VirtualKeyModifiers.Control, VirtualKey.C);
 
-    public XamlUICommand ZoomOutCommand { get; } = new()
-    {
-        Label = IllustrationViewerPageResources.ZoomOut,
-        IconSource = new SymbolIconSource
-        {
-            Symbol = Symbol.ZoomOut
-        },
-        KeyboardAccelerators =
-        {
-            new KeyboardAccelerator
-            {
-                Key = VirtualKey.Subtract
-            }
-        }
-    };
+    // The gif will be played as soon as its loaded, so the default state is playing and thus we need the button to be pause
+    public XamlUICommand PlayGifCommand { get; } = IllustrationViewerPageResources.PauseGif.GetCommand(FontIconSymbols.StopE71A);
 
-    public XamlUICommand ZoomInCommand { get; } = new()
-    {
-        Label = IllustrationViewerPageResources.ZoomIn,
-        IconSource = new SymbolIconSource
-        {
-            Symbol = Symbol.ZoomIn
-        },
-        KeyboardAccelerators =
-        {
-            new KeyboardAccelerator
-            {
-                Key = VirtualKey.Add
-            }
-        }
-    };
+    public XamlUICommand ZoomOutCommand { get; } = IllustrationViewerPageResources.ZoomOut.GetCommand(
+        FontIconSymbols.ZoomOutE71F, VirtualKey.Subtract);
+
+    public XamlUICommand ZoomInCommand { get; } = IllustrationViewerPageResources.ZoomIn.GetCommand(
+        FontIconSymbols.ZoomInE8A3, VirtualKey.Add);
 
     public XamlUICommand BookmarkCommand { get; private set; } = null!; // the null-state is transient
 
-    public StandardUICommand SaveCommand { get; } = new(StandardUICommandKind.Save) { Description = MiscResources.Save };
+    public XamlUICommand SaveCommand { get; } = IllustrationViewerPageResources.Save.GetCommand(
+        FontIconSymbols.SaveE74E, VirtualKeyModifiers.Control, VirtualKey.S);
 
-    public XamlUICommand SaveAsCommand { get; } = new()
-    {
-        Label = IllustrationViewerPageResources.SaveAs,
-        KeyboardAccelerators =
-        {
-            new KeyboardAccelerator
-            {
-                Modifiers = VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift,
-                Key = VirtualKey.S
-            }
-        },
-        IconSource = FontIconSymbols.SaveAsE792.GetFontIconSource()
-    };
+    public XamlUICommand SaveAsCommand { get; } = IllustrationViewerPageResources.SaveAs.GetCommand(
+        FontIconSymbols.SaveAsE792, VirtualKeyModifiers.Control | VirtualKeyModifiers.Shift, VirtualKey.S);
 
-    public XamlUICommand AddToBookmarkCommand { get; } = new()
-    {
-        Label = IllustrationViewerPageResources.AddToBookmark,
-        IconSource = FontIconSymbols.BookmarksE8A4.GetFontIconSource()
-    };
+    public XamlUICommand SetAsCommand { get; } = IllustrationViewerPageResources.SetAs.GetCommand(FontIconSymbols.PersonalizeE771);
 
-    public XamlUICommand GenerateLinkCommand { get; } = new()
-    {
-        Label = IllustrationViewerPageResources.GenerateLink,
-        IconSource = FontIconSymbols.LinkE71B.GetFontIconSource()
-    };
+    public XamlUICommand AddToBookmarkCommand { get; } = IllustrationViewerPageResources.AddToBookmark.GetCommand(FontIconSymbols.BookmarksE8A4);
 
-    public XamlUICommand GenerateWebLinkCommand { get; } = new()
-    {
-        Label = IllustrationViewerPageResources.GenerateWebLink,
-        IconSource = FontIconSymbols.PreviewLinkE8A1.GetFontIconSource()
-    };
+    public XamlUICommand GenerateLinkCommand { get; } = IllustrationViewerPageResources.GenerateLink.GetCommand(FontIconSymbols.LinkE71B);
 
-    public XamlUICommand OpenInWebBrowserCommand { get; } = new()
-    {
-        Label = IllustrationViewerPageResources.OpenInWebBrowser,
-        IconSource = FontIconSymbols.WebSearchF6FA.GetFontIconSource()
-    };
+    public XamlUICommand GenerateWebLinkCommand { get; } = IllustrationViewerPageResources.GenerateWebLink.GetCommand(FontIconSymbols.PreviewLinkE8A1);
+
+    public XamlUICommand OpenInWebBrowserCommand { get; } = IllustrationViewerPageResources.OpenInWebBrowser.GetCommand(FontIconSymbols.WebSearchF6FA);
 
     public StandardUICommand ShareCommand { get; } = new(StandardUICommandKind.Share);
 
-    public XamlUICommand ShowQrCodeCommand { get; } = new()
-    {
-        Label = IllustrationViewerPageResources.ShowQRCode,
-        IconSource = FontIconSymbols.QRCodeED14.GetFontIconSource()
-    };
+    public XamlUICommand ShowQrCodeCommand { get; } = IllustrationViewerPageResources.ShowQRCode.GetCommand(FontIconSymbols.QRCodeED14);
 
-    public XamlUICommand SetAsLockScreenCommand { get; } = new()
-    {
-        Label = IllustrationViewerPageResources.LockScreen
-    };
+    public XamlUICommand SetAsLockScreenCommand { get; } = new() { Label = IllustrationViewerPageResources.LockScreen };
 
-    public XamlUICommand SetAsBackgroundCommand { get; } = new()
-    {
-        Label = IllustrationViewerPageResources.Background
-    };
+    public XamlUICommand SetAsBackgroundCommand { get; } = new() { Label = IllustrationViewerPageResources.Background };
 
-    public XamlUICommand FullScreenCommand { get; } = new()
-    {
-        Label = IllustrationViewerPageResources.FullScreen,
-        IconSource = FontIconSymbols.FullScreenE740.GetFontIconSource()
-    };
+    public XamlUICommand FullScreenCommand { get; } = IllustrationViewerPageResources.FullScreen.GetCommand(FontIconSymbols.FullScreenE740);
 
-    public XamlUICommand RestoreResolutionCommand { get; } = new()
-    {
-        Label = IllustrationViewerPageResources.RestoreOriginalResolution,
-        IconSource = FontIconSymbols.WebcamE8B8.GetFontIconSource()
-    };
+    public XamlUICommand RestoreResolutionCommand { get; } = IllustrationViewerPageResources.RestoreOriginalResolution.GetCommand(FontIconSymbols.WebcamE8B8);
 
     #endregion
 

--- a/src/Pixeval/Pages/IllustrationViewer/ImageViewerPage.xaml
+++ b/src/Pixeval/Pages/IllustrationViewer/ImageViewerPage.xaml
@@ -1,73 +1,85 @@
-﻿<controls:EnhancedPage x:Class="Pixeval.Pages.IllustrationViewer.ImageViewerPage"
-                       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                       xmlns:controls="using:Pixeval.Controls"
-                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                       xmlns:ui="using:Pixeval.Util.UI"
-                       mc:Ignorable="d">
+<controls:EnhancedPage
+    x:Class="Pixeval.Pages.IllustrationViewer.ImageViewerPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Pixeval.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="using:Pixeval.Util.UI"
+    mc:Ignorable="d">
     <Grid>
-        <Grid x:Name="IllustrationOriginalImageContainer"
-              HorizontalAlignment="Stretch"
-              VerticalAlignment="Stretch"
-              ui:ClipService.ClipToBounds="True"
-              PointerWheelChanged="IllustrationOriginalImageContainer_OnPointerWheelChanged">
-            <Image x:Name="IllustrationOriginalImage"
-                   HorizontalAlignment="Center"
-                   VerticalAlignment="Center"
-                   DoubleTapped="IllustrationOriginalImage_OnDoubleTapped"
-                   IsDoubleTapEnabled="True"
-                   ManipulationDelta="IllustrationOriginalImage_OnManipulationDelta"
-                   ManipulationMode="TranslateX,TranslateY"
-                   RenderTransformOrigin="0.5,0.5"
-                   Source="{x:Bind _viewModel.OriginalImageSource, Mode=OneWay}"
-                   Stretch="Uniform">
+        <Grid
+            x:Name="IllustrationOriginalImageContainer"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            ui:ClipService.ClipToBounds="True"
+            PointerWheelChanged="IllustrationOriginalImageContainer_OnPointerWheelChanged">
+            <Image
+                x:Name="IllustrationOriginalImage"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                DoubleTapped="IllustrationOriginalImage_OnDoubleTapped"
+                IsDoubleTapEnabled="True"
+                ManipulationDelta="IllustrationOriginalImage_OnManipulationDelta"
+                ManipulationMode="TranslateX,TranslateY"
+                RenderTransformOrigin="0.5,0.5"
+                Source="{x:Bind _viewModel.OriginalImageSource, Mode=OneWay}"
+                Stretch="Uniform">
                 <Image.ContextFlyout>
-                    <MenuFlyout>
-                        <MenuFlyoutItem x:Uid="/ImageViewerPage/IllustrationInfoAndCommentsMenuFlyoutItem"
-                                        Icon="{ui:FontIcon Glyph=InfoE946}"
-                                        Tapped="IllustrationInfoAndCommentsMenuFlyoutItem_OnTapped">
-                            <MenuFlyoutItem.KeyboardAccelerators>
+                    <CommandBarFlyout>
+                        <AppBarButton
+                            x:Uid="/ImageViewerPage/IllustrationInfoAndCommentsMenuFlyoutItem"
+                            Icon="{ui:FontIcon Glyph=InfoE946}"
+                            Tapped="IllustrationInfoAndCommentsMenuFlyoutItem_OnTapped">
+                            <AppBarButton.KeyboardAccelerators>
                                 <KeyboardAccelerator Key="F12" />
-                            </MenuFlyoutItem.KeyboardAccelerators>
-                        </MenuFlyoutItem>
-                        <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.PlayGifCommand}" Visibility="{x:Bind _viewModel.IllustrationViewerPageViewModel.IsUgoira}" />
-                        <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.ZoomInCommand}" />
-                        <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.ZoomOutCommand}" />
-                        <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.BookmarkCommand}" />
-                        <MenuFlyoutSeparator />
-                        <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.CopyCommand}" />
-                        <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.SaveCommand}" />
-                        <MenuFlyoutSeparator />
-                        <MenuFlyoutSubItem x:Uid="/ImageViewerPage/SetAsSubItem" Icon="{ui:FontIcon Glyph=PersonalizeE771}">
-                            <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.SetAsBackgroundCommand}" />
-                            <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.SetAsLockScreenCommand}" />
-                        </MenuFlyoutSubItem>
-                        <MenuFlyoutSeparator />
-                        <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.GenerateLinkCommand}" />
-                        <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.GenerateWebLinkCommand}" />
-                        <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.OpenInWebBrowserCommand}" />
-                        <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.ShowQrCodeCommand}" />
-                        <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.ShareCommand}" />
-                    </MenuFlyout>
+                            </AppBarButton.KeyboardAccelerators>
+                        </AppBarButton>
+                        <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.PlayGifCommand}" Visibility="{x:Bind _viewModel.IllustrationViewerPageViewModel.IsUgoira}" />
+                        <!--<AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.ZoomInCommand}" />
+                        <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.ZoomOutCommand}" />-->
+                        <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.BookmarkCommand}" />
+                        <AppBarSeparator />
+                        <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.CopyCommand}" />
+                        <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.SaveCommand}" />
+                        <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.ShareCommand}" />
+                        <CommandBarFlyout.SecondaryCommands>
+                            <AppBarButton x:Uid="/ImageViewerPage/SetAsSubItem" Icon="{ui:FontIcon Glyph=PersonalizeE771}">
+                                <AppBarButton.Flyout>
+                                    <MenuFlyout>
+                                        <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.SetAsBackgroundCommand}" />
+                                        <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.SetAsLockScreenCommand}" />
+                                    </MenuFlyout>
+                                </AppBarButton.Flyout>
+                            </AppBarButton>
+                            <AppBarSeparator />
+                            <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.GenerateLinkCommand}" />
+                            <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.GenerateWebLinkCommand}" />
+                            <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.OpenInWebBrowserCommand}" />
+                            <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.ShowQrCodeCommand}" />
+                        </CommandBarFlyout.SecondaryCommands>
+                    </CommandBarFlyout>
                 </Image.ContextFlyout>
                 <Image.RenderTransform>
                     <CompositeTransform x:Name="IllustrationOriginalImageRenderTransform" />
                 </Image.RenderTransform>
             </Image>
         </Grid>
-        <Grid HorizontalAlignment="Stretch"
-              VerticalAlignment="Stretch"
-              Visibility="{x:Bind _viewModel.GetLoadingMaskVisibility(_viewModel.LoadingOriginalSourceTask), Mode=OneWay}">
+        <Grid
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            Visibility="{x:Bind _viewModel.GetLoadingMaskVisibility(_viewModel.LoadingOriginalSourceTask), Mode=OneWay}">
             <Rectangle Fill="{ThemeResource PixevalAppAcrylicBrush}" />
             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                <ProgressRing Width="50"
-                              Height="50"
-                              IsIndeterminate="False"
-                              Value="{x:Bind _viewModel.LoadingProgress, Mode=OneWay}" />
-                <TextBlock Margin="0,10,0,0"
-                           FontSize="{StaticResource PixevalSubscriptFontSize}"
-                           Text="{x:Bind _viewModel.LoadingText, Mode=OneWay}" />
+                <ProgressRing
+                    Width="50"
+                    Height="50"
+                    IsIndeterminate="False"
+                    Value="{x:Bind _viewModel.LoadingProgress, Mode=OneWay}" />
+                <TextBlock
+                    Margin="0,10,0,0"
+                    FontSize="{StaticResource PixevalSubscriptFontSize}"
+                    Text="{x:Bind _viewModel.LoadingText, Mode=OneWay}" />
             </StackPanel>
         </Grid>
     </Grid>

--- a/src/Pixeval/Pages/IllustrationViewer/ImageViewerPage.xaml
+++ b/src/Pixeval/Pages/IllustrationViewer/ImageViewerPage.xaml
@@ -26,25 +26,19 @@
                 Source="{x:Bind _viewModel.OriginalImageSource, Mode=OneWay}"
                 Stretch="Uniform">
                 <Image.ContextFlyout>
+                    <!--  Todo: PrimaryCommands 点击后不会自动隐藏Flyout，等待wasdk修复或者加上Close的Handler  -->
                     <CommandBarFlyout>
-                        <AppBarButton
-                            x:Uid="/ImageViewerPage/IllustrationInfoAndCommentsMenuFlyoutItem"
-                            Icon="{ui:FontIcon Glyph=InfoE946}"
-                            Tapped="IllustrationInfoAndCommentsMenuFlyoutItem_OnTapped">
-                            <AppBarButton.KeyboardAccelerators>
-                                <KeyboardAccelerator Key="F12" />
-                            </AppBarButton.KeyboardAccelerators>
-                        </AppBarButton>
+                        <AppBarToggleButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.IllustrationInfoAndCommentsCommand}" IsChecked="{x:Bind _viewModel.IllustrationViewerPageViewModel.IsInfoPaneOpen, Mode=TwoWay}" />
                         <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.PlayGifCommand}" Visibility="{x:Bind _viewModel.IllustrationViewerPageViewModel.IsUgoira}" />
-                        <!--<AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.ZoomInCommand}" />
-                        <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.ZoomOutCommand}" />-->
                         <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.BookmarkCommand}" />
                         <AppBarSeparator />
                         <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.CopyCommand}" />
                         <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.SaveCommand}" />
                         <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.ShareCommand}" />
                         <CommandBarFlyout.SecondaryCommands>
-                            <AppBarButton x:Uid="/ImageViewerPage/SetAsSubItem" Icon="{ui:FontIcon Glyph=PersonalizeE771}">
+                            <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.ZoomInCommand}" />
+                            <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.ZoomOutCommand}" />
+                            <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.SetAsCommand}">
                                 <AppBarButton.Flyout>
                                     <MenuFlyout>
                                         <MenuFlyoutItem Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.SetAsBackgroundCommand}" />
@@ -53,10 +47,14 @@
                                 </AppBarButton.Flyout>
                             </AppBarButton>
                             <AppBarSeparator />
-                            <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.GenerateLinkCommand}" />
+                            <!--<AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.GenerateLinkCommand}" />-->
                             <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.GenerateWebLinkCommand}" />
                             <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.OpenInWebBrowserCommand}" />
-                            <AppBarButton Command="{x:Bind _viewModel.IllustrationViewerPageViewModel.ShowQrCodeCommand}" />
+                            <!--<AppBarButton
+                                Command="{x:Bind _viewModel.ShowQrCodeCommand}"
+                                x:Uid="/ImageViewerPage/ShowQRCode"
+                                Icon="{ui:FontIcon Glyph=QRCodeED14}"
+                                Tapped="ShowQrCodeCommandOnExecuteRequested" />-->
                         </CommandBarFlyout.SecondaryCommands>
                     </CommandBarFlyout>
                 </Image.ContextFlyout>

--- a/src/Pixeval/Pages/IllustrationViewer/ImageViewerPage.xaml.cs
+++ b/src/Pixeval/Pages/IllustrationViewer/ImageViewerPage.xaml.cs
@@ -21,7 +21,6 @@
 using System;
 using System.Threading.Tasks;
 using Windows.Foundation;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
@@ -115,20 +114,15 @@ public sealed partial class ImageViewerPage
                 illustWidth,
                 illustHeight,
                 IllustrationOriginalImage.ActualWidth,
-                IllustrationOriginalImage.ActualHeight, 
+                IllustrationOriginalImage.ActualHeight,
                 GetZoomFactor());
             Zoom(displayImageResolution >= 1 ? displayImageResolution * 2 : 1 / displayImageResolution - GetZoomFactor());
         }
     }
 
     private void IllustrationOriginalImageContainer_OnPointerWheelChanged(object sender, PointerRoutedEventArgs e)
-    { 
-        Zoom(e.GetCurrentPoint(null).Properties.MouseWheelDelta / 1000d);
-    }
-
-    private void IllustrationInfoAndCommentsMenuFlyoutItem_OnTapped(object sender, TappedRoutedEventArgs e)
     {
-        _viewModel.IllustrationViewerPageViewModel.IsInfoPaneOpen = true;
+        Zoom(e.GetCurrentPoint(null).Properties.MouseWheelDelta / 1000d);
     }
 
     #region Helper Functions
@@ -138,7 +132,7 @@ public sealed partial class ImageViewerPage
         EasingMode = EasingMode.EaseOut,
         Exponent = 12
     };
-    
+
     private double GetZoomFactor()
     {
         return IllustrationOriginalImageRenderTransform.ScaleX;

--- a/src/Pixeval/Pixeval.csproj
+++ b/src/Pixeval/Pixeval.csproj
@@ -51,7 +51,7 @@
         <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
         <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-        <PackageReference Include="WinUI3Utilities" Version="1.1.3.1" />
+        <PackageReference Include="WinUI3Utilities" Version="1.1.3.2" />
         <PackageReference Include="WinUIEx" Version="2.2.0" />
 
         <ProjectReference Include="..\Pixeval.CoreApi\Pixeval.CoreApi.csproj" />

--- a/src/Pixeval/Popups/AppPopup.cs
+++ b/src/Pixeval/Popups/AppPopup.cs
@@ -132,15 +132,15 @@ public class AppPopup
         {
             HorizontalAlignment = HorizontalAlignment.Stretch,
             VerticalAlignment = VerticalAlignment.Stretch,
-            Background = (Brush) Application.Current.Resources["ApplicationPageBackgroundThemeBrush"],
+            Background = (Brush)Application.Current.Resources["ApplicationPageBackgroundThemeBrush"],
             Opacity = 0.4
         };
         var popupContentPresenter = new ContentPresenter
         {
             Shadow = themeShadow,
             Translation = new Vector3(0, 0, 40),
-            BorderBrush = (Brush) Application.Current.Resources["PixevalBorderBrush"],
-            Background = (Brush) Application.Current.Resources["PixevalPanelBackgroundThemeBrush"],
+            BorderBrush = (Brush)Application.Current.Resources["PixevalBorderBrush"],
+            Background = (Brush)Application.Current.Resources["PixevalPanelBackgroundThemeBrush"],
             CornerRadius = new CornerRadius(10),
             HorizontalAlignment = HorizontalAlignment.Center,
             VerticalAlignment = VerticalAlignment.Center,

--- a/src/Pixeval/Strings/zh-CN/IllustrationViewerPage.resw
+++ b/src/Pixeval/Strings/zh-CN/IllustrationViewerPage.resw
@@ -120,14 +120,8 @@
   <data name="AddToBookmark" xml:space="preserve">
     <value>添加到收藏夹</value>
   </data>
-  <data name="AddToBookmarkButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>添加到收藏夹</value>
-  </data>
   <data name="Background" xml:space="preserve">
     <value>壁纸</value>
-  </data>
-  <data name="BookmarkButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>收藏/取消收藏</value>
   </data>
   <data name="CannotShareImageForNowContent" xml:space="preserve">
     <value>您必须等待图片加载完毕才能分享，如果仅仅是为了分享链接，可以点击上方的“生成网页链接”或者“生成本页链接”按钮将图片链接复制到剪切板</value>
@@ -138,8 +132,8 @@
   <data name="CommentsTab.Content" xml:space="preserve">
     <value>评论</value>
   </data>
-  <data name="CopyButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>复制</value>
+  <data name="Copy" xml:space="preserve">
+    <value>复制图片到剪切板</value>
   </data>
   <data name="FullScreen" xml:space="preserve">
     <value>全屏</value>
@@ -162,22 +156,13 @@
   <data name="GenerateWebLink" xml:space="preserve">
     <value>复制网页链接</value>
   </data>
-  <data name="IllustrationInfoAndCommentsButton.Label" xml:space="preserve">
-    <value>详情</value>
-  </data>
-  <data name="IllustrationInfoAndCommentsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>详情</value>
-  </data>
-  <data name="IllustrationInfoTab.Content" xml:space="preserve">
+  <data name="IllustrationInfoAndComments" xml:space="preserve">
     <value>详情</value>
   </data>
   <data name="LockScreen" xml:space="preserve">
     <value>锁屏</value>
   </data>
   <data name="OpenInWebBrowser" xml:space="preserve">
-    <value>打开网页</value>
-  </data>
-  <data name="OpenInWebBrowserButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>打开网页</value>
   </data>
   <data name="OriginalmageStreamIsEmptyContent" xml:space="preserve">
@@ -188,6 +173,9 @@
   </data>
   <data name="PlayGif" xml:space="preserve">
     <value>播放</value>
+  </data>
+  <data name="QrCodeTeachingTip.Title" xml:space="preserve">
+    <value>图片链接二维码</value>
   </data>
   <data name="RelatedWorksTab.Content" xml:space="preserve">
     <value>推荐作品</value>
@@ -201,29 +189,17 @@
   <data name="SaveAs" xml:space="preserve">
     <value>另存为</value>
   </data>
-  <data name="SaveAsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>另存为</value>
-  </data>
-  <data name="SaveButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>保存</value>
-  </data>
-  <data name="SaveCurrentImageButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>保存</value>
-  </data>
   <data name="SaveManga" xml:space="preserve">
     <value>保存图集</value>
   </data>
   <data name="SaveMangaAs" xml:space="preserve">
     <value>图集另存为</value>
   </data>
+  <data name="SetAs" xml:space="preserve">
+    <value>设置为</value>
+  </data>
   <data name="SetAsBackgroundSucceededTitle" xml:space="preserve">
     <value>已设置背景</value>
-  </data>
-  <data name="SetAsButton.Label" xml:space="preserve">
-    <value>设置为</value>
-  </data>
-  <data name="SetAsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>设置为</value>
   </data>
   <data name="SetAsLockScreenSucceededTitle" xml:space="preserve">
     <value>已设置锁屏</value>
@@ -231,16 +207,10 @@
   <data name="SetAsSucceededTitle" xml:space="preserve">
     <value>设置成功</value>
   </data>
-  <data name="ShareButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>分享</value>
-  </data>
   <data name="ShareTitleFormatted" xml:space="preserve">
     <value>分享{0}</value>
   </data>
   <data name="ShowQRCode" xml:space="preserve">
-    <value>生成二维码</value>
-  </data>
-  <data name="ShowQrCodeButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>生成二维码</value>
   </data>
   <data name="UniformToFillResolution" xml:space="preserve">
@@ -252,13 +222,7 @@
   <data name="ZoomIn" xml:space="preserve">
     <value>放大</value>
   </data>
-  <data name="ZoomInButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>放大</value>
-  </data>
   <data name="ZoomOut" xml:space="preserve">
-    <value>缩小</value>
-  </data>
-  <data name="ZoomOutButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>缩小</value>
   </data>
 </root>

--- a/src/Pixeval/Strings/zh-CN/ImageViewerPage.resw
+++ b/src/Pixeval/Strings/zh-CN/ImageViewerPage.resw
@@ -132,7 +132,7 @@
   <data name="DownloadingImageFormatted" xml:space="preserve">
     <value>正在下载图片: {0}%</value>
   </data>
-  <data name="IllustrationInfoAndCommentsMenuFlyoutItem.Text" xml:space="preserve">
+  <data name="IllustrationInfoAndCommentsMenuFlyoutItem.Label" xml:space="preserve">
     <value>作品信息</value>
   </data>
   <data name="LoadingFromCache" xml:space="preserve">
@@ -144,7 +144,7 @@
   <data name="MergingGifFrames" xml:space="preserve">
     <value>正在合成GIF...</value>
   </data>
-  <data name="SetAsSubItem.Text" xml:space="preserve">
+  <data name="SetAsSubItem.Label" xml:space="preserve">
     <value>设置为</value>
   </data>
 </root>

--- a/src/Pixeval/Strings/zh-CN/ImageViewerPage.resw
+++ b/src/Pixeval/Strings/zh-CN/ImageViewerPage.resw
@@ -144,7 +144,4 @@
   <data name="MergingGifFrames" xml:space="preserve">
     <value>正在合成GIF...</value>
   </data>
-  <data name="SetAsSubItem.Label" xml:space="preserve">
-    <value>设置为</value>
-  </data>
 </root>

--- a/src/Pixeval/UserControls/IllustrationView/RiverFlowIllustrationView.xaml.cs
+++ b/src/Pixeval/UserControls/IllustrationView/RiverFlowIllustrationView.xaml.cs
@@ -124,7 +124,7 @@ public sealed partial class RiverFlowIllustrationView
         var window = WindowFactory.Fork(
             new AppHelper.InitializeInfo { TitleBarType = TitleBarHelper.TitleBarType.AppWindow, Size = new SizeInt32(width, height) },
             CurrentContext.Window,
-            onLoaded: (o, _) => o.To<Frame>().Navigate(typeof(IllustrationViewerPage),
+            (o, _) => o.To<Frame>().Navigate(typeof(IllustrationViewerPage),
                 new IllustrationViewerPageViewModel(this, viewModels), new SuppressNavigationTransitionInfo()));
         window.Activate();
     }

--- a/src/Pixeval/Util/UI/Windowing/WindowFactory.cs
+++ b/src/Pixeval/Util/UI/Windowing/WindowFactory.cs
@@ -34,12 +34,11 @@ public static class WindowFactory
     public static CustomizableWindow Fork(
         AppHelper.InitializeInfo provider,
         Window owner,
-        FrameworkElement? titleBar = null,
         RoutedEventHandler? onLoaded = null)
     {
         var w = new CustomizableWindow(owner, onLoaded);
         w.Closed += (_, _) => ForkedWindowsInternal.Remove(w);
-        AppHelper.Initialize(provider, w, null, titleBar);
+        AppHelper.Initialize(provider, w);
         ForkedWindowsInternal.Add(w);
         return w;
     }

--- a/src/Pixeval/Util/UI/XamlUICommandHelper.cs
+++ b/src/Pixeval/Util/UI/XamlUICommandHelper.cs
@@ -1,0 +1,68 @@
+#region Copyright (c) Pixeval/Pixeval
+// GPL v3 License
+// 
+// Pixeval/Pixeval
+// Copyright (c) 2023 Pixeval/XamlUICommandHelper.cs
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#endregion
+
+using Windows.System;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+
+namespace Pixeval.Util.UI;
+
+public static class XamlUICommandHelper
+{
+    public static XamlUICommand GetCommand(this string label, FontIconSymbols icon)
+    {
+        return new()
+        {
+            Label = label,
+            Description = label,
+            IconSource = icon.GetFontIconSource()
+        };
+    }
+
+    public static XamlUICommand GetCommand(this string label, FontIconSymbols icon, VirtualKey key)
+    {
+        return new()
+        {
+            Label = label,
+            IconSource = icon.GetFontIconSource(),
+            KeyboardAccelerators = { new KeyboardAccelerator { Key = key } }
+        };
+    }
+
+    public static XamlUICommand GetCommand(this string label, FontIconSymbols icon, VirtualKeyModifiers modifiers, VirtualKey key)
+    {
+        return new()
+        {
+            Label = label,
+            IconSource = icon.GetFontIconSource(),
+            KeyboardAccelerators = { new KeyboardAccelerator { Modifiers = modifiers, Key = key } }
+        };
+    }
+
+    public static XamlUICommand GetCommand(this string label, IconSource icon, VirtualKeyModifiers modifiers, VirtualKey key)
+    {
+        return new()
+        {
+            Label = label,
+            IconSource = icon,
+            KeyboardAccelerators = { new KeyboardAccelerator { Modifiers = modifiers, Key = key } }
+        };
+    }
+}

--- a/src/Pixeval/packages.lock.json
+++ b/src/Pixeval/packages.lock.json
@@ -221,12 +221,12 @@
       },
       "WinUI3Utilities": {
         "type": "Direct",
-        "requested": "[1.1.3.1, )",
-        "resolved": "1.1.3.1",
-        "contentHash": "M0HUwuLP9w0RQD0z5y4ei6SiZCedzLFlaFmPiWyUFEO2+qvKWrFCNZ6zIefR+Cwj7Qu512CcZmnHe7k7nJKSJQ==",
+        "requested": "[1.1.3.2, )",
+        "resolved": "1.1.3.2",
+        "contentHash": "YXWOZBBHMncnZqmhZ/A/JYMtiNLMveGF075nijYSlp017Y6fjcP2KhlQ9NwpEwIoRAoOBke2/ivCu3lW5d+ejw==",
         "dependencies": {
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756",
-          "Microsoft.WindowsAppSDK": "1.3.230331000"
+          "Microsoft.WindowsAppSDK": "1.3.230602002"
         }
       },
       "WinUIEx": {


### PR DESCRIPTION
优化：
* [x] CommandBarFlyout代替MenuFlyout，缩减长度，并删除一些功能
* [x] 标题栏Grid中控件宽度自动适应
* [x] CommandBar中按钮宽度根据是否收纳自动适应
* [x] 绘画题目设置最大宽度，并折行
* [x] 弃用Popup，改用TeachingTip，并修复找不到Target的bug
* [x] 关闭IllustrationViewerPage键盘快捷键提示（Esc）
* [x] 删除ToolTip使用更方便的XamlUICommand.Description
* [x] 取消CustomizableWindow中无用的TitleBar和Grid
* [x] 使用DragZoneHelper（见ISupportCustomTitleBarDragRegionTest），从而可动态计算Pane宽度
* [x] 其他简化代码
* [ ] 点击CommandBarFlyout后自动隐藏
* [ ] 简化剪切板SetBitmap流程