### PR TITLE
修复动态代理

### DIFF
--- a/src/Pixeval.Utilities/Logging/FileLogger.cs
+++ b/src/Pixeval.Utilities/Logging/FileLogger.cs
@@ -121,12 +121,15 @@ public class ExceptionModel
 {
     public ExceptionModel(Exception exception)
     {
+        Exception = exception;
         Source = exception.Source;
         Message = exception.Message;
         StackTrace = exception.StackTrace;
         if (exception.InnerException is not null)
             InnerException = new ExceptionModel(exception.InnerException);
     }
+
+    public Exception Exception { get; }
 
     public string? Source { get; }
 
@@ -138,6 +141,7 @@ public class ExceptionModel
 
     public string ToString(int indent) =>
         $"""
+         {Indent(indent)}Type: {Exception.GetType().FullName}
          {Indent(indent)}Source: {Source}
          {Indent(indent)}Message: {Message}
          {Indent(indent)}StackTrace: 

--- a/src/Pixeval/Pages/Misc/SettingsPage.xaml.cs
+++ b/src/Pixeval/Pages/Misc/SettingsPage.xaml.cs
@@ -196,7 +196,6 @@ public sealed partial class SettingsPage
         }
     }
 
-
     private void SetPathMacroRichEditBoxDocument(string path)
     {
         DefaultDownloadPathMacroTextBox.Document.SetText(TextSetOptions.None, "");
@@ -229,7 +228,6 @@ public sealed partial class SettingsPage
             _ => throw new ArgumentOutOfRangeException(nameof(tree))
         };
     }
-
 
     [GeneratedRegex(@"\\par(?!d)")]
     private static partial Regex RtpNewLineRegex();


### PR DESCRIPTION
Refresh proxy when `HttpClient` Exception was thrown.

closes #363 