### PR TITLE
修复文本框bug

### DIFF
--- a/src/Pixeval/AppManagement/AppSettings.cs
+++ b/src/Pixeval/AppManagement/AppSettings.cs
@@ -165,6 +165,7 @@ public partial record AppSettings : IWindowSettings
     [SettingsEntry(IconGlyph.HardDriveEDA2, nameof(SettingsPageResources.ImageMirrorServerEntryHeader), nameof(SettingsPageResources.ImageMirrorServerEntryDescription))]
     public string? MirrorHost { get; set; } = null;
 
+    [SettingsEntry(IconGlyph.HistoryE81C, nameof(SettingsPageResources.MaximumBrowseHistoryRecordsEntryHeader), nameof(SettingsPageResources.MaximumBrowseHistoryRecordsEntryDescription))]
     public int MaximumBrowseHistoryRecords { get; set; } = 100;
 
     public DateTimeOffset SearchStartDate { get; set; } = DateTimeOffset.Now - TimeSpan.FromDays(1);

--- a/src/Pixeval/Controls/Settings/DownloadMacroSettingsExpander.xaml.cs
+++ b/src/Pixeval/Controls/Settings/DownloadMacroSettingsExpander.xaml.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Windows.UI;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.UI;
 using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using Pixeval.Controls.Windowing;
 using Pixeval.Download;
 using Pixeval.Download.MacroParser;
@@ -39,11 +39,26 @@ public sealed partial class DownloadMacroSettingsExpander
     /// </summary>
     private string _previousPath = "";
 
+    private void DownloadMacroSettingsExpander_OnLoading(FrameworkElement sender, object args)
+    {
+        Entry.PropertyChanged += (_, _) => EntryOnPropertyChanged();
+        EntryOnPropertyChanged();
+
+        return;
+        void EntryOnPropertyChanged()
+        {
+            // The first time viewmodel get the value of DefaultDownloadPathMacro from AppSettings won't trigger the property changed event
+            _previousPath = Entry.DefaultDownloadPathMacro;
+            SetPathMacroRichEditBoxDocument(Entry.DefaultDownloadPathMacro);
+        }
+    }
+
     private void DefaultDownloadPathMacroTextBox_OnGotFocus(object sender, RoutedEventArgs e)
     {
         DownloadMacroInvalidInfoBar.IsOpen = false;
         _previousPath = Entry.DefaultDownloadPathMacro;
-        sender.As<RichEditBox>().Document.Selection.CharacterFormat.ForegroundColor = Colors.White;
+        if (sender.To<RichEditBox>().Document.Selection is { Length: 0 } selection)
+            selection.CharacterFormat.ForegroundColor = Application.Current.GetResource<SolidColorBrush>("TextFillColorPrimaryBrush").Color;
     }
 
     private void DefaultDownloadPathMacroTextBox_OnLostFocus(object sender, RoutedEventArgs e)
@@ -81,6 +96,7 @@ public sealed partial class DownloadMacroSettingsExpander
 
     private void SetPathMacroRichEditBoxDocument(string path)
     {
+        DefaultDownloadPathMacroTextBox.Document.BeginUndoGroup();
         DefaultDownloadPathMacroTextBox.Document.SetText(TextSetOptions.None, "");
         _pathParser.SetupParsingEnvironment(new Lexer(path));
         if (_pathParser.Parse() is { } result)
@@ -92,6 +108,7 @@ public sealed partial class DownloadMacroSettingsExpander
                 action(textRange);
             }
         }
+        DefaultDownloadPathMacroTextBox.Document.EndUndoGroup();
     }
 
     private static (bool, string?) ValidateMacro(IMetaPathNode<string> tree, IDownloadTaskFactory<IllustrationItemViewModel, IllustrationDownloadTask> macroProvider)
@@ -115,6 +132,11 @@ public sealed partial class DownloadMacroSettingsExpander
     [GeneratedRegex(@"\\par(?!d)")]
     private static partial Regex RtpNewLineRegex();
 
+    private static (int start, int endExclusive) AppendDocumentText(RichEditTextDocument document, string text)
+    {
+        return InsertDocumentText(document, text, -1);
+    }
+
     private static (int start, int endExclusive) InsertDocumentText(RichEditTextDocument document, string text, int position)
     {
         document.GetText(TextGetOptions.None, out var txt);
@@ -125,11 +147,6 @@ public sealed partial class DownloadMacroSettingsExpander
         document.SetText(TextSetOptions.FormatRtf, RtpNewLineRegex().Replace(rtf, ""));
 
         return position is -1 ? (txt.Length - 1, txt.Length + text.Length - 1) : (position - 1, position - 1);
-    }
-
-    private static (int start, int endExclusive) AppendDocumentText(RichEditTextDocument document, string text)
-    {
-        return InsertDocumentText(document, text, -1);
     }
 
     // ReSharper disable TailRecursiveCall
@@ -180,8 +197,9 @@ public sealed partial class DownloadMacroSettingsExpander
 
     private void DefaultDownloadPathMacroTextBox_OnTextChanged(object sender, RoutedEventArgs e)
     {
-        sender.As<RichEditBox>().Document.GetText(TextGetOptions.None, out var text);
-        sender.As<RichEditBox>().Document.Selection.CharacterFormat.ForegroundColor = Colors.White;
+        sender.To<RichEditBox>().Document.GetText(TextGetOptions.None, out var text);
+        if (sender.To<RichEditBox>().Document.Selection is { Length: 0 } selection)
+            selection.CharacterFormat.ForegroundColor = Application.Current.GetResource<SolidColorBrush>("TextFillColorPrimaryBrush").Color;
         Entry.DefaultDownloadPathMacro = text.ReplaceLineEndings("");
     }
 
@@ -199,19 +217,5 @@ public sealed partial class DownloadMacroSettingsExpander
     private void DefaultDownloadPathMacroEntry_OnTapped(object sender, TappedRoutedEventArgs e)
     {
         _ = this.CreateAcknowledgementAsync(SettingsPageResources.MacroTutorialDialogTitle, SettingsPageResources.MacroTutorialDialogContent);
-    }
-
-    private void DownloadMacroSettingsExpander_OnLoading(FrameworkElement sender, object args)
-    {
-        Entry.PropertyChanged += (_, _) => EntryOnPropertyChanged();
-        EntryOnPropertyChanged();
-
-        return;
-        void EntryOnPropertyChanged()
-        {
-            // The first time viewmodel get the value of DefaultDownloadPathMacro from AppSettings won't trigger the property changed event
-            _previousPath = Entry.DefaultDownloadPathMacro;
-            SetPathMacroRichEditBoxDocument(Entry.DefaultDownloadPathMacro);
-        }
     }
 }

--- a/src/Pixeval/Pages/Misc/SettingsPageViewModel.cs
+++ b/src/Pixeval/Pages/Misc/SettingsPageViewModel.cs
@@ -150,12 +150,13 @@ public partial class SettingsPageViewModel : UiObservableObject, IDisposable
                     SettingsPageResources.RankOptionEntryDescription,
                     IconGlyph.MarketEAFC,
                     [
-                        new EnumAppSettingsEntry<IllustrationDownloadFormat>(AppSetting,
+                        new EnumAppSettingsEntry<RankOption>(AppSetting,
                             WorkTypeEnum.Illustration,
-                            nameof(AppSettings.IllustrationDownloadFormat)),
-                        new EnumAppSettingsEntry<NovelDownloadFormat>(AppSetting,
+                            nameof(AppSettings.IllustrationRankOption)),
+                        new EnumAppSettingsEntry(AppSetting,
                             WorkTypeEnum.Novel,
-                            nameof(AppSettings.NovelDownloadFormat))
+                            nameof(AppSettings.NovelRankOption),
+                            RankOptionExtension.NovelRankOptions)
                     ]),
                 new MultiValuesAppSettingsEntry(AppSetting,
                     SettingsPageResources.DefaultSearchTagMatchOptionEntryHeader,

--- a/src/Pixeval/Pages/Misc/SettingsPageViewModel.cs
+++ b/src/Pixeval/Pages/Misc/SettingsPageViewModel.cs
@@ -215,6 +215,7 @@ public partial class SettingsPageViewModel : UiObservableObject, IDisposable
                 new IntAppSettingsEntry(AppSetting,
                     nameof(AppSettings.MaximumBrowseHistoryRecords))
                 {
+                    Placeholder = SettingsPageResources.MaximumBrowseHistoryRecordsNumerBoxPlaceholderText,
                     Max = 200,
                     Min = 10
                 },

--- a/src/Pixeval/Strings/zh-cn/LoginPage.resjson
+++ b/src/Pixeval/Strings/zh-cn/LoginPage.resjson
@@ -10,7 +10,7 @@
     "SubmitWithNewAccountButton/Text": "登录并且不使用当前账号",
     "SubmitButton/Content": "登录",
     "RefreshTokenButton/Content": "使用刷新令牌登录",
-    "BrowserButton/Content": "使用Chrome/Edge浏览器登录",
+    "BrowserButton/Content": "使用Chrome/Edge浏览器登录🚧（测试）",
     "WebViewButton/Content": "使用WebView登录",
     "RefreshTokenBox/PlaceholderText": "刷新令牌",
     "UserNameBox/PlaceholderText": "邮箱地址或pixiv ID",


### PR DESCRIPTION
close #392 

尽量修了一下，把设置文本框颜色的操作合并为一个了，就不会出现撤销时颜色一个一个消失的bug，但重新染色后第一次撤销时，会删除所有内容（第二次后回到正常，都怪这个破控件）

另外根据不同主题设置了不同文字颜色，“透明”的情况不会出现了