### PR TITLE
详情页界面优化

### DIFF
--- a/src/Pixeval.Controls/AppBarNumberItem.xaml
+++ b/src/Pixeval.Controls/AppBarNumberItem.xaml
@@ -10,7 +10,7 @@
     Padding="5,0"
     HorizontalContentAlignment="Center"
     VerticalContentAlignment="Center"
-    Foreground="{StaticResource TextFillColorSecondaryBrush}"
+    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
     mc:Ignorable="d">
     <controls:DockPanel HorizontalSpacing="5">
         <TextBlock

--- a/src/Pixeval.Controls/AppBarTextItem.xaml
+++ b/src/Pixeval.Controls/AppBarTextItem.xaml
@@ -10,7 +10,7 @@
     Padding="5,0"
     HorizontalContentAlignment="Center"
     VerticalContentAlignment="Center"
-    Foreground="{StaticResource TextFillColorSecondaryBrush}"
+    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
     mc:Ignorable="d">
     <controls:DockPanel HorizontalSpacing="5">
         <fluent:SymbolIcon

--- a/src/Pixeval.Controls/DigitalSignalItem.xaml
+++ b/src/Pixeval.Controls/DigitalSignalItem.xaml
@@ -13,7 +13,7 @@
         Height="7"
         Fill="{x:Bind Fill, Mode=OneWay}" />
     <TextBlock
-        Foreground="{StaticResource TextFillColorSecondaryBrush}"
+        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
         Style="{StaticResource CaptionTextBlockStyle}"
         Text="{x:Bind Text, Mode=OneWay}" />
 </controls:DockPanel>

--- a/src/Pixeval.Controls/HeartButton.xaml
+++ b/src/Pixeval.Controls/HeartButton.xaml
@@ -52,7 +52,7 @@
         <ScaleTransform CenterX="10" CenterY="10" ScaleX="0" ScaleY="0" />
     </Grid.RenderTransform>
     <fluent:SymbolIcon
-        Foreground="{StaticResource LayerFillColorDefaultBrush}"
+        Foreground="{ThemeResource LayerFillColorDefaultBrush}"
         IconVariant="Filled"
         Symbol="Heart" />
     <IconSourceElement IconSource="{x:Bind Command.IconSource, Mode=OneWay}" />

--- a/src/Pixeval.Controls/IconText.xaml
+++ b/src/Pixeval.Controls/IconText.xaml
@@ -13,11 +13,11 @@
         VerticalAlignment="Center"
         controls:DockPanel.Dock="Left"
         FontSize="{StaticResource SmallIconFontSize}"
-        Foreground="{x:Bind IconForeground, Mode=OneWay}"
+        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
         Symbol="{x:Bind Symbol, Mode=OneWay}" />
     <TextBlock
         VerticalAlignment="Center"
-        Foreground="{x:Bind TextForeground, Mode=OneWay}"
+        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
         Style="{StaticResource BaseTextBlockStyle}"
         Text="{x:Bind Text, Mode=OneWay}" />
 </controls:DockPanel>

--- a/src/Pixeval.Controls/IconText.xaml.cs
+++ b/src/Pixeval.Controls/IconText.xaml.cs
@@ -1,13 +1,10 @@
 using FluentIcons.Common;
-using Microsoft.UI.Xaml.Media;
 using WinUI3Utilities.Attributes;
 
 namespace Pixeval.Controls;
 
 [DependencyProperty<Symbol>("Symbol")]
 [DependencyProperty<string>("Text")]
-[DependencyProperty<Brush>("IconForeground")]
-[DependencyProperty<Brush>("TextForeground")]
 public sealed partial class IconText
 {
     public IconText() => InitializeComponent();

--- a/src/Pixeval/Behaviors/ButtonCopyBehavior.cs
+++ b/src/Pixeval/Behaviors/ButtonCopyBehavior.cs
@@ -1,8 +1,7 @@
-using System;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Xaml.Interactivity;
-using Windows.ApplicationModel.DataTransfer;
+using Pixeval.Util.UI;
 using WinUI3Utilities.Attributes;
 
 namespace Pixeval.Behaviors;
@@ -23,12 +22,8 @@ public partial class ButtonCopyBehavior : Behavior<Button>
     }
     private void OnClick(object sender, RoutedEventArgs e)
     {
-        if(string.IsNullOrEmpty(TargetText))
-        {
+        if (string.IsNullOrEmpty(TargetText))
             return;
-        }
-        var package = new DataPackage();
-        package.SetText(TargetText);
-        Clipboard.SetContent(package);
+        UiHelper.ClipboardSetText(TargetText);
     }
 }

--- a/src/Pixeval/Behaviors/ButtonCopyBehavior.cs
+++ b/src/Pixeval/Behaviors/ButtonCopyBehavior.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.Xaml.Interactivity;
+using Windows.ApplicationModel.DataTransfer;
+using WinUI3Utilities.Attributes;
+
+namespace Pixeval.Behaviors;
+
+[DependencyProperty<string>("TargetText")]
+public partial class ButtonCopyBehavior : Behavior<Button>
+{
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        AssociatedObject.Click += OnClick;
+    }
+
+    protected override void OnDetaching()
+    {
+        base.OnDetaching();
+        AssociatedObject.Click -= OnClick;
+    }
+    private void OnClick(object sender, RoutedEventArgs e)
+    {
+        if(string.IsNullOrEmpty(TargetText))
+        {
+            return;
+        }
+        var package = new DataPackage();
+        package.SetText(TargetText);
+        Clipboard.SetContent(package);
+    }
+}

--- a/src/Pixeval/Controls/Download/DownloadItem.xaml
+++ b/src/Pixeval/Controls/Download/DownloadItem.xaml
@@ -59,11 +59,11 @@
                 Text="{x:Bind ViewModel.DownloadTask.ActiveCount, Mode=OneWay}"
                 Visibility="{x:Bind local:C.IsNotZeroToVisibility(ViewModel.DownloadTask.ActiveCount), Mode=OneWay}" />
             <local:DigitalSignalItem
-                Fill="{StaticResource SystemFillColorSuccessBrush}"
+                Fill="{ThemeResource SystemFillColorSuccessBrush}"
                 Text="{x:Bind ViewModel.DownloadTask.CompletedCount, Mode=OneWay}"
                 Visibility="{x:Bind local:C.IsNotZeroToVisibility(ViewModel.DownloadTask.CompletedCount), Mode=OneWay}" />
             <local:DigitalSignalItem
-                Fill="{StaticResource SystemFillColorCriticalBrush}"
+                Fill="{ThemeResource SystemFillColorCriticalBrush}"
                 Text="{x:Bind ViewModel.DownloadTask.ErrorCount, Mode=OneWay}"
                 Visibility="{x:Bind local:C.IsNotZeroToVisibility(ViewModel.DownloadTask.ErrorCount), Mode=OneWay}" />
         </StackPanel>

--- a/src/Pixeval/Controls/Illustration/IllustrationItem.xaml
+++ b/src/Pixeval/Controls/Illustration/IllustrationItem.xaml
@@ -95,7 +95,7 @@
                 Visibility="{x:Bind local:C.ToVisibility(ViewModel.IsUgoira), Mode=OneWay}" />
             <Grid controls:DockPanel.Dock="Right">
                 <fluent:SymbolIcon
-                    Foreground="{StaticResource LayerFillColorDefaultBrush}"
+                    Foreground="{ThemeResource LayerFillColorDefaultBrush}"
                     IconVariant="Filled"
                     Symbol="SquareMultiple"
                     Visibility="{x:Bind local:C.ToVisibility(ViewModel.IsManga), Mode=OneWay}" />

--- a/src/Pixeval/Controls/Illustrator/IllustratorItem.xaml
+++ b/src/Pixeval/Controls/Illustrator/IllustratorItem.xaml
@@ -10,7 +10,7 @@
     xmlns:local="using:Pixeval.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     AspectRatio="15:8"
-    Background="{StaticResource CardBackgroundFillColorDefaultBrush}"
+    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
     mc:Ignorable="d">
     <!--  图片长宽均为5，故为(3*5):(3+5)  -->
     <Grid>
@@ -45,10 +45,10 @@
                     VerticalAlignment="Center"
                     Content="{fluent:SymbolIcon Symbol=Guest,
                                                 FontSize=12}"
-                    Foreground="{StaticResource TextFillColorSecondaryBrush}" />
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                 <TextBlock
                     VerticalAlignment="Center"
-                    Foreground="{StaticResource TextFillColorSecondaryBrush}"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                     Style="{StaticResource CaptionStrongTextBlockStyle}"
                     Text="{x:Bind ViewModel.UserId, Mode=OneWay}" />
                 <local:PixevalBadge

--- a/src/Pixeval/Controls/Novel/NovelItem.xaml
+++ b/src/Pixeval/Controls/Novel/NovelItem.xaml
@@ -11,7 +11,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:model="using:Pixeval.CoreApi.Model"
     xmlns:pixeval="using:Pixeval.AppManagement"
-    Background="{StaticResource CardBackgroundFillColorDefaultBrush}"
+    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
     PointerEntered="NovelItem_OnPointerEntered"
     PointerExited="NovelItem_OnPointerExited"
     mc:Ignorable="d">
@@ -148,7 +148,7 @@
         <Grid
             Height="310"
             Padding="10"
-            Background="{StaticResource ApplicationPageBackgroundThemeBrush}"
+            Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
             ColumnSpacing="10"
             CornerRadius="{StaticResource ControlCornerRadius}"
             PointerEntered="NovelItemPopup_OnPointerEntered"

--- a/src/Pixeval/Controls/Work/WorkViewerSplitView.xaml
+++ b/src/Pixeval/Controls/Work/WorkViewerSplitView.xaml
@@ -15,7 +15,7 @@
         PaneBackground="Transparent">
         <SplitView.Pane>
             <Grid
-                BorderBrush="{StaticResource ApplicationPageBackgroundThemeBrush}"
+                BorderBrush="{ThemeResource ApplicationPageBackgroundThemeBrush}"
                 CornerRadius="4"
                 Translation="0,0,40">
                 <NavigationView

--- a/src/Pixeval/Pages/IllustrationViewer/IllustrationViewerPage.xaml
+++ b/src/Pixeval/Pages/IllustrationViewer/IllustrationViewerPage.xaml
@@ -18,45 +18,24 @@
     Unloaded="IllustrationViewerPage_OnUnloaded"
     mc:Ignorable="d">
     <controls:EnhancedWindowPage.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.ThemeDictionaries>
-                <ResourceDictionary x:Key="Default">
-                    <SolidColorBrush x:Key="BottomBarInfoForeground">#9F9F9F</SolidColorBrush>
-                    <SolidColorBrush x:Key="BottomBarBackground">#FCF8F5</SolidColorBrush>
-                </ResourceDictionary>
-                <ResourceDictionary x:Key="Light">
-                    <SolidColorBrush x:Key="BottomBarInfoForeground">#9F9F9F</SolidColorBrush>
-                    <SolidColorBrush x:Key="BottomBarBackground">#FCF8F5</SolidColorBrush>
-                </ResourceDictionary>
-                <ResourceDictionary x:Key="Dark">
-                    <SolidColorBrush x:Key="BottomBarInfoForeground">#7F7F7F</SolidColorBrush>
-                    <SolidColorBrush x:Key="BottomBarBackground">#2A2725</SolidColorBrush>
-                </ResourceDictionary>
-                <ResourceDictionary x:Key="HighContrast">
-                    <SolidColorBrush x:Key="BottomBarInfoForeground">#7F7F7F</SolidColorBrush>
-                    <SolidColorBrush x:Key="BottomBarBackground">#2A2725</SolidColorBrush>
-                </ResourceDictionary>
-            </ResourceDictionary.ThemeDictionaries>
-
-            <Thickness x:Key="NormalMargin">0,48,0,0</Thickness>
-            <AcrylicBrush
-                x:Key="BottomCommandSectionBackground"
-                FallbackColor="{StaticResource SecondaryAccentColor}"
-                TintColor="{StaticResource SecondaryAccentColor}"
-                TintLuminosityOpacity="0.8"
-                TintOpacity="0.8" />
-            <Style
-                x:Key="TextBlockStyle"
-                BasedOn="{StaticResource CaptionStrongTextBlockStyle}"
-                TargetType="TextBlock">
-                <Setter Property="FontSize" Value="15" />
-                <Setter Property="Margin" Value="10,0" />
-                <Setter Property="VerticalAlignment" Value="Center" />
-                <Setter Property="HorizontalTextAlignment" Value="Center" />
-                <Setter Property="TextAlignment" Value="Center" />
-                <Setter Property="TextTrimming" Value="CharacterEllipsis" />
-            </Style>
-        </ResourceDictionary>
+        <Thickness x:Key="NormalMargin">0,48,0,0</Thickness>
+        <AcrylicBrush
+            x:Key="BottomCommandSectionBackground"
+            FallbackColor="{StaticResource SecondaryAccentColor}"
+            TintColor="{StaticResource SecondaryAccentColor}"
+            TintLuminosityOpacity="0.8"
+            TintOpacity="0.8" />
+        <Style
+            x:Key="TextBlockStyle"
+            BasedOn="{StaticResource CaptionStrongTextBlockStyle}"
+            TargetType="TextBlock">
+            <Setter Property="FontSize" Value="15" />
+            <Setter Property="Margin" Value="10,0" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+            <Setter Property="HorizontalTextAlignment" Value="Center" />
+            <Setter Property="TextAlignment" Value="Center" />
+            <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+        </Style>
     </controls:EnhancedWindowPage.Resources>
     <controls:EnhancedWindowPage.KeyboardAccelerators>
         <KeyboardAccelerator Key="Escape" Invoked="ExitFullScreenKeyboardAccelerator_OnInvoked" />
@@ -136,7 +115,7 @@
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Bottom"
                                     Background="{StaticResource BottomCommandSectionBackground}"
-                                    BorderBrush="{StaticResource SecondaryAccentBorderBrush}"
+                                    BorderBrush="{ThemeResource SecondaryAccentBorderBrush}"
                                     BorderThickness="0.5"
                                     CornerRadius="{ThemeResource ControlCornerRadius}"
                                     Opacity="0.7"
@@ -192,7 +171,7 @@
                                 Margin="150,0"
                                 HorizontalAlignment="Center"
                                 Background="{StaticResource BottomCommandSectionBackground}"
-                                BorderBrush="{StaticResource SecondaryAccentBorderBrush}"
+                                BorderBrush="{ThemeResource SecondaryAccentBorderBrush}"
                                 BorderThickness="0.5"
                                 CornerRadius="{ThemeResource ControlCornerRadius}"
                                 Translation="0,0,30">
@@ -251,7 +230,7 @@
                 Grid.Row="1"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch"
-                Background="{ThemeResource BottomBarBackground}">
+                Background="{ThemeResource SolidBackgroundFillColorTertiaryBrush}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" MaxWidth="310" />
                     <ColumnDefinition Width="*" />
@@ -267,13 +246,13 @@
                     <AppBarSeparator />
                     <controls:AppBarTextItem
                         Padding="15,0"
-                        Foreground="{ThemeResource BottomBarInfoForeground}"
+                        Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
                         Symbol="SlideGrid"
                         Text="{x:Bind _viewModel.CurrentIllustration.SizeText, Mode=OneWay}" />
                     <AppBarSeparator />
                     <controls:AppBarTextItem
                         Padding="15,0"
-                        Foreground="{ThemeResource BottomBarInfoForeground}"
+                        Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
                         Symbol="AppTitle"
                         Text="{x:Bind _viewModel.CurrentIllustration.Title, Mode=OneWay}" />
                 </CommandBar>
@@ -494,7 +473,7 @@
                     <VisualState.Setters>
                         <Setter Target="WorkViewerSplitViewGrid.Margin" Value="0" />
                         <Setter Target="TopCommandBarTranslation.Y" Value="{StaticResource NegativeTitleBarHeight}" />
-                        <Setter Target="TitleBarArea.Background" Value="{StaticResource PixevalAppAcrylicBrush}" />
+                        <Setter Target="TitleBarArea.Background" Value="{ThemeResource PixevalAppAcrylicBrush}" />
                         <Setter Target="TitleBarBorder.Background" Value="Transparent" />
                     </VisualState.Setters>
                 </VisualState>

--- a/src/Pixeval/Pages/IllustratorViewer/IllustratorViewerPage.xaml
+++ b/src/Pixeval/Pages/IllustratorViewer/IllustratorViewerPage.xaml
@@ -19,7 +19,7 @@
             </controls:StickyHeaderScrollView.HeaderBackGround>
             <controls:StickyHeaderScrollView.Header>
                 <!--  220 + 32  -->
-                <Grid Height="252" Background="{StaticResource PixevalTranslucentBackgroundBrush}">
+                <Grid Height="252" Background="{ThemeResource PixevalTranslucentBackgroundBrush}">
                     <Grid.RowDefinitions>
                         <RowDefinition x:Name="ScrollableLength" Height="*" />
                         <RowDefinition Height="Auto" />

--- a/src/Pixeval/Pages/NovelViewer/NovelViewerPage.xaml
+++ b/src/Pixeval/Pages/NovelViewer/NovelViewerPage.xaml
@@ -148,7 +148,7 @@
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Bottom"
                                     Background="{StaticResource BottomCommandSectionBackground}"
-                                    BorderBrush="{StaticResource SecondaryAccentBorderBrush}"
+                                    BorderBrush="{ThemeResource SecondaryAccentBorderBrush}"
                                     BorderThickness="0.5"
                                     CornerRadius="{ThemeResource ControlCornerRadius}"
                                     Opacity="0.7"
@@ -200,7 +200,7 @@
                                 Margin="150,0"
                                 HorizontalAlignment="Center"
                                 Background="{StaticResource BottomCommandSectionBackground}"
-                                BorderBrush="{StaticResource SecondaryAccentBorderBrush}"
+                                BorderBrush="{ThemeResource SecondaryAccentBorderBrush}"
                                 BorderThickness="0.5"
                                 CornerRadius="{ThemeResource ControlCornerRadius}"
                                 Translation="0,0,30">
@@ -413,7 +413,7 @@
                     <VisualState.Setters>
                         <Setter Target="EntryViewerSplitView.Margin" Value="0" />
                         <Setter Target="TopCommandBarTranslation.Y" Value="{StaticResource NegativeTitleBarHeight}" />
-                        <Setter Target="TitleBarArea.Background" Value="{StaticResource PixevalAppAcrylicBrush}" />
+                        <Setter Target="TitleBarArea.Background" Value="{ThemeResource PixevalAppAcrylicBrush}" />
                         <Setter Target="TitleBarBorder.Background" Value="Transparent" />
                     </VisualState.Setters>
                 </VisualState>

--- a/src/Pixeval/Pages/WorkViewer/WorkInfoPage.xaml
+++ b/src/Pixeval/Pages/WorkViewer/WorkInfoPage.xaml
@@ -11,6 +11,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:model="using:Pixeval.CoreApi.Model"
     xmlns:pixeval="using:Pixeval.AppManagement"
+    xmlns:ui="using:CommunityToolkit.WinUI"
     mc:Ignorable="d">
     <controls2:EnhancedPage.Resources>
         <Style
@@ -34,77 +35,94 @@
         HorizontalScrollBarVisibility="Disabled"
         HorizontalScrollMode="Disabled"
         VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="20,15">
-            <TextBlock x:Uid="/WorkInfoPage/TitleTextBlock" Style="{StaticResource SubtitleTextBlockStyle}" />
-            <!--#region Illustrator Info-->
-            <TextBlock x:Uid="/WorkInfoPage/IllustratorTextBlock" Style="{StaticResource InfoPageSectionHeaderTextBlockStyle}" />
-            <Button
-                Margin="{StaticResource StackLayoutEntryPadding}"
-                Click="IllustratorPersonPicture_OnClicked"
-                Style="{StaticResource CardControlButton}">
-                <controls:DockPanel HorizontalSpacing="10" LastChildFill="False">
-                    <PersonPicture
-                        Width="50"
-                        Height="50"
-                        controls:DockPanel.Dock="Left"
-                        ProfilePicture="{x:Bind _viewModel.AvatarSource, Mode=OneWay}" />
-                    <TextBlock controls:DockPanel.Dock="Top" Style="{StaticResource BodyTextBlockStyle}">
-                        <Run x:Uid="/WorkInfoPage/IllustratorName" />
-                        <Run Text="{x:Bind _viewModel.Illustrator.Name}" />
-                    </TextBlock>
-                    <TextBlock controls:DockPanel.Dock="Bottom" Style="{StaticResource BodyTextBlockStyle}">
-                        <Run x:Uid="/WorkInfoPage/IllustratorId" />
-                        <Run Text="{x:Bind _viewModel.Illustrator.Id}" />
-                    </TextBlock>
-                </controls:DockPanel>
-            </Button>
-            <!--#endregion-->
-            <!--#region Work Title-->
-            <TextBlock x:Uid="/WorkInfoPage/WorkTitleTextBlock" Style="{StaticResource InfoPageSectionHeaderTextBlockStyle}" />
-            <TextBlock Style="{StaticResource InfoPageSectionContentTextBlockStyle}" Text="{x:Bind _viewModel.Entry.Title}" />
-            <!--#endregion-->
-            <!--#region Work Id-->
-            <TextBlock x:Uid="/WorkInfoPage/WorkIdTextBlock" Style="{StaticResource InfoPageSectionHeaderTextBlockStyle}" />
-            <TextBlock Style="{StaticResource InfoPageSectionContentTextBlockStyle}" Text="{x:Bind _viewModel.Entry.Id}" />
-            <!--#endregion-->
-            <!--#region Work Caption-->
-            <TextBlock x:Uid="/WorkInfoPage/WorkCaptionTextBlock" Style="{StaticResource InfoPageSectionHeaderTextBlockStyle}" />
+        <StackPanel Margin="20,15" Spacing="4">
+            <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="{x:Bind _viewModel.Entry.Title}" />
             <labs:MarkdownTextBlock
                 x:Name="WorkCaptionMarkdownTextBlock"
                 Margin="{StaticResource StackLayoutEntryPadding}"
-                FontSize="{StaticResource CaptionTextBlockFontSize}"
                 Text="">
                 <labs:MarkdownTextBlock.Config>
                     <labs:MarkdownConfig />
                 </labs:MarkdownTextBlock.Config>
             </labs:MarkdownTextBlock>
+            <StackPanel Orientation="Horizontal">
+                <TextBlock VerticalAlignment="Center" Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}">
+                    <Run Text="PID" />
+                    <Run Text="{x:Bind _viewModel.Entry.Id}" />
+                </TextBlock>
+                <Button
+                    Padding="4"
+                    VerticalAlignment="Center"
+                    Background="Transparent"
+                    BorderBrush="Transparent"
+                    Content="{ui:FontIcon FontSize=12,
+                                          Glyph=&#xE8C8;}" />
+            </StackPanel>
+
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <FontIcon FontSize="14" Glyph="&#xE890;" />
+                <TextBlock Text="{x:Bind _viewModel.Entry.TotalView}" />
+                <FontIcon
+                    Margin="12,0,0,0"
+                    FontSize="14"
+                    Glyph="&#xE006;" />
+                <TextBlock Text="{x:Bind _viewModel.Entry.TotalBookmarks}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <FontIcon FontSize="14" Glyph="&#xE917;" />
+                <TextBlock Text="{x:Bind controls2:C.CultureDateTimeOffsetFormatter(_viewModel.Entry.CreateDate, pixeval:AppSettings.CurrentCulture)}" />
+            </StackPanel>
+            <!--#region Illustrator Info-->
+            <Button
+                Margin="0,12,0,0"
+                Click="IllustratorPersonPicture_OnClicked"
+                Style="{StaticResource CardControlButton}">
+                <controls:DockPanel HorizontalSpacing="12" LastChildFill="False">
+                    <PersonPicture
+                        Width="50"
+                        Height="50"
+                        controls:DockPanel.Dock="Left"
+                        ProfilePicture="{x:Bind _viewModel.AvatarSource, Mode=OneWay}" />
+                    <TextBlock
+                        controls:DockPanel.Dock="Top"
+                        Style="{StaticResource SubtitleTextBlockStyle}"
+                        TextWrapping="Wrap">
+                        <Run Text="{x:Bind _viewModel.Illustrator.Name}" />
+                    </TextBlock>
+                    <StackPanel controls:DockPanel.Dock="Bottom" Orientation="Horizontal">
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}"
+                            Text="{x:Bind _viewModel.Illustrator.Id}" />
+                        <Button
+                            Padding="4"
+                            VerticalAlignment="Center"
+                            Background="Transparent"
+                            BorderBrush="Transparent"
+                            Content="{ui:FontIcon FontSize=12,
+                                                  Glyph=&#xE8C8;}" />
+                    </StackPanel>
+
+                </controls:DockPanel>
+            </Button>
             <!--#endregion-->
-            <TextBlock x:Uid="/WorkInfoPage/WorkTotalBookmarksTextBlock" Style="{StaticResource InfoPageSectionHeaderTextBlockStyle}" />
-            <TextBlock Style="{StaticResource InfoPageSectionContentTextBlockStyle}" Text="{x:Bind _viewModel.Entry.TotalBookmarks}" />
-            <TextBlock x:Uid="/WorkInfoPage/WorkTotalViewsTextBlock" Style="{StaticResource InfoPageSectionHeaderTextBlockStyle}" />
-            <TextBlock Style="{StaticResource InfoPageSectionContentTextBlockStyle}" Text="{x:Bind _viewModel.Entry.TotalView}" />
-            <TextBlock
-                x:Uid="/WorkInfoPage/IllustrationDimensionTextBlock"
-                Style="{StaticResource InfoPageSectionHeaderTextBlockStyle}"
-                Visibility="{x:Bind controls2:C.IsNotNullToVisibility(_viewModel.IllustrationDimensionText)}" />
-            <TextBlock
-                Style="{StaticResource InfoPageSectionContentTextBlockStyle}"
-                Text="{x:Bind _viewModel.IllustrationDimensionText}"
-                Visibility="{x:Bind controls2:C.IsNotNullToVisibility(_viewModel.IllustrationDimensionText)}" />
-            <TextBlock x:Uid="/WorkInfoPage/WorkUploadDateTextBlock" Style="{StaticResource InfoPageSectionHeaderTextBlockStyle}" />
-            <TextBlock Style="{StaticResource InfoPageSectionContentTextBlockStyle}" Text="{x:Bind controls2:C.CultureDateTimeOffsetFormatter(_viewModel.Entry.CreateDate, pixeval:AppSettings.CurrentCulture)}" />
-            <TextBlock x:Uid="/WorkInfoPage/WorkTagListTextBlock" Style="{StaticResource InfoPageSectionHeaderTextBlockStyle}" />
-            <ItemsRepeater Margin="{StaticResource StackLayoutEntryPadding}" ItemsSource="{x:Bind _viewModel.Entry.Tags}">
+            <!--#region Work Id-->
+            <!--#endregion-->
+            <!--#region Work Caption-->
+            <!--#endregion-->
+            <ItemsRepeater Margin="0,12,0,0" ItemsSource="{x:Bind _viewModel.Entry.Tags}">
                 <ItemsRepeater.Layout>
-                    <controls:WrapLayout HorizontalSpacing="5" VerticalSpacing="5" />
+                    <controls:WrapLayout HorizontalSpacing="8" VerticalSpacing="8" />
                 </ItemsRepeater.Layout>
                 <ItemsRepeater.ItemTemplate>
                     <DataTemplate x:DataType="model:Tag">
-                        <Button
-                            Click="WorkTagButton_OnClicked"
-                            Content="{x:Bind Name}"
-                            FontSize="{StaticResource CaptionTextBlockFontSize}"
-                            ToolTipService.ToolTip="{x:Bind ToolTip}">
+                        <Button Click="WorkTagButton_OnClicked" ToolTipService.ToolTip="{x:Bind ToolTip}">
+                            <Button.Content>
+                                <TextBlock TextWrapping="Wrap">
+                                    <Run Text="{x:Bind Name}" />
+                                    <Run Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}" Text="{x:Bind TranslatedName}" />
+                                </TextBlock>
+                            </Button.Content>
                             <Button.ContextFlyout>
                                 <MenuFlyout>
                                     <MenuFlyoutItem

--- a/src/Pixeval/Pages/WorkViewer/WorkInfoPage.xaml
+++ b/src/Pixeval/Pages/WorkViewer/WorkInfoPage.xaml
@@ -104,7 +104,10 @@
                 </ItemsRepeater.Layout>
                 <ItemsRepeater.ItemTemplate>
                     <DataTemplate x:DataType="model:Tag">
-                        <Button Tag="{x:Bind Name}" Click="WorkTagButton_OnClicked" ToolTipService.ToolTip="{x:Bind ToolTip}">
+                        <Button
+                            Click="WorkTagButton_OnClicked"
+                            Tag="{x:Bind Name}"
+                            ToolTipService.ToolTip="{x:Bind ToolTip}">
                             <Button.Content>
                                 <TextBlock TextWrapping="Wrap">
                                     <Run Text="{x:Bind Name}" />

--- a/src/Pixeval/Pages/WorkViewer/WorkInfoPage.xaml
+++ b/src/Pixeval/Pages/WorkViewer/WorkInfoPage.xaml
@@ -39,26 +39,18 @@
                     VerticalAlignment="Center"
                     Background="Transparent"
                     BorderBrush="Transparent"
-                    Content="{ui:FontIcon FontSize=12,
-                                          Glyph=&#xE8C8;}">
+                    Content="{ui:SymbolIcon FontSize=12,
+                                            Symbol=Copy}">
                     <i:Interaction.Behaviors>
                         <behaviors:ButtonCopyBehavior TargetText="{x:Bind _viewModel.Entry.Id}" />
                     </i:Interaction.Behaviors>
                 </Button>
             </StackPanel>
-            <StackPanel Orientation="Horizontal" Spacing="4">
-                <FontIcon FontSize="14" Glyph="&#xE890;" />
-                <TextBlock Text="{x:Bind _viewModel.Entry.TotalView}" />
-                <FontIcon
-                    Margin="12,0,0,0"
-                    FontSize="14"
-                    Glyph="&#xE006;" />
-                <TextBlock Text="{x:Bind _viewModel.Entry.TotalBookmarks}" />
+            <StackPanel Orientation="Horizontal" Spacing="20">
+                <controls2:IconText Symbol="Eye" Text="{x:Bind _viewModel.Entry.TotalView}" />
+                <controls2:IconText Symbol="Heart" Text="{x:Bind _viewModel.Entry.TotalBookmarks}" />
             </StackPanel>
-            <StackPanel Orientation="Horizontal" Spacing="4">
-                <FontIcon FontSize="14" Glyph="&#xE917;" />
-                <TextBlock Text="{x:Bind controls2:C.CultureDateTimeOffsetFormatter(_viewModel.Entry.CreateDate, pixeval:AppSettings.CurrentCulture)}" />
-            </StackPanel>
+            <controls2:IconText Symbol="Clock" Text="{x:Bind controls2:C.CultureDateTimeOffsetFormatter(_viewModel.Entry.CreateDate, pixeval:AppSettings.CurrentCulture)}" />
             <!--#region Illustrator Info-->
             <Button
                 Margin="0,12,0,0"
@@ -86,8 +78,8 @@
                             VerticalAlignment="Center"
                             Background="Transparent"
                             BorderBrush="Transparent"
-                            Content="{ui:FontIcon FontSize=12,
-                                                  Glyph=&#xE8C8;}">
+                            Content="{ui:SymbolIcon FontSize=12,
+                                                    Symbol=Copy}">
                             <i:Interaction.Behaviors>
                                 <behaviors:ButtonCopyBehavior TargetText="{x:Bind _viewModel.Illustrator.Id}" />
                             </i:Interaction.Behaviors>

--- a/src/Pixeval/Pages/WorkViewer/WorkInfoPage.xaml
+++ b/src/Pixeval/Pages/WorkViewer/WorkInfoPage.xaml
@@ -2,10 +2,12 @@
     x:Class="Pixeval.Pages.WorkInfoPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="using:Pixeval.Behaviors"
     xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:controls2="using:Pixeval.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:fluent="using:FluentIcons.WinUI"
+    xmlns:i="using:Microsoft.Xaml.Interactivity"
     xmlns:labs="using:CommunityToolkit.Labs.WinUI.MarkdownTextBlock"
     xmlns:local="using:Pixeval.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -13,24 +15,6 @@
     xmlns:pixeval="using:Pixeval.AppManagement"
     xmlns:ui="using:CommunityToolkit.WinUI"
     mc:Ignorable="d">
-    <controls2:EnhancedPage.Resources>
-        <Style
-            x:Key="InfoPageSectionHeaderTextBlockStyle"
-            BasedOn="{StaticResource CaptionTextBlockStyle}"
-            TargetType="TextBlock">
-            <Setter Property="Margin" Value="{StaticResource StackLayoutEntriesMargin}" />
-            <Setter Property="Foreground" Value="{ThemeResource TextBoxDisabledForegroundThemeBrush}" />
-        </Style>
-        <Style
-            x:Key="InfoPageSectionContentTextBlockStyle"
-            BasedOn="{StaticResource CaptionTextBlockStyle}"
-            TargetType="TextBlock">
-            <Setter Property="Margin" Value="{StaticResource StackLayoutEntryPadding}" />
-            <Setter Property="TextTrimming" Value="CharacterEllipsis" />
-            <Setter Property="TextWrapping" Value="Wrap" />
-            <Setter Property="MaxHeight" Value="200" />
-        </Style>
-    </controls2:EnhancedPage.Resources>
     <ScrollViewer
         HorizontalScrollBarVisibility="Disabled"
         HorizontalScrollMode="Disabled"
@@ -56,9 +40,12 @@
                     Background="Transparent"
                     BorderBrush="Transparent"
                     Content="{ui:FontIcon FontSize=12,
-                                          Glyph=&#xE8C8;}" />
+                                          Glyph=&#xE8C8;}">
+                    <i:Interaction.Behaviors>
+                        <behaviors:ButtonCopyBehavior TargetText="{x:Bind _viewModel.Entry.Id}" />
+                    </i:Interaction.Behaviors>
+                </Button>
             </StackPanel>
-
             <StackPanel Orientation="Horizontal" Spacing="4">
                 <FontIcon FontSize="14" Glyph="&#xE890;" />
                 <TextBlock Text="{x:Bind _viewModel.Entry.TotalView}" />
@@ -100,23 +87,24 @@
                             Background="Transparent"
                             BorderBrush="Transparent"
                             Content="{ui:FontIcon FontSize=12,
-                                                  Glyph=&#xE8C8;}" />
+                                                  Glyph=&#xE8C8;}">
+                            <i:Interaction.Behaviors>
+                                <behaviors:ButtonCopyBehavior TargetText="{x:Bind _viewModel.Illustrator.Id}" />
+                            </i:Interaction.Behaviors>
+                        </Button>
                     </StackPanel>
 
                 </controls:DockPanel>
             </Button>
             <!--#endregion-->
-            <!--#region Work Id-->
-            <!--#endregion-->
-            <!--#region Work Caption-->
-            <!--#endregion-->
+            <!--#region Tags-->
             <ItemsRepeater Margin="0,12,0,0" ItemsSource="{x:Bind _viewModel.Entry.Tags}">
                 <ItemsRepeater.Layout>
                     <controls:WrapLayout HorizontalSpacing="8" VerticalSpacing="8" />
                 </ItemsRepeater.Layout>
                 <ItemsRepeater.ItemTemplate>
                     <DataTemplate x:DataType="model:Tag">
-                        <Button Click="WorkTagButton_OnClicked" ToolTipService.ToolTip="{x:Bind ToolTip}">
+                        <Button Tag="{x:Bind Name}" Click="WorkTagButton_OnClicked" ToolTipService.ToolTip="{x:Bind ToolTip}">
                             <Button.Content>
                                 <TextBlock TextWrapping="Wrap">
                                     <Run Text="{x:Bind Name}" />
@@ -136,6 +124,7 @@
                     </DataTemplate>
                 </ItemsRepeater.ItemTemplate>
             </ItemsRepeater>
+            <!--#endregion-->
         </StackPanel>
     </ScrollViewer>
 </controls2:EnhancedPage>

--- a/src/Pixeval/Pages/WorkViewer/WorkInfoPage.xaml.cs
+++ b/src/Pixeval/Pages/WorkViewer/WorkInfoPage.xaml.cs
@@ -22,7 +22,6 @@ using System;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using Pixeval.AppManagement;
 using Pixeval.CoreApi.Global.Enum;

--- a/src/Pixeval/Pages/WorkViewer/WorkInfoPage.xaml.cs
+++ b/src/Pixeval/Pages/WorkViewer/WorkInfoPage.xaml.cs
@@ -49,7 +49,7 @@ public sealed partial class WorkInfoPage
 
     private void WorkTagButton_OnClicked(object sender, RoutedEventArgs e)
     {
-        _ = WeakReferenceMessenger.Default.Send(new WorkTagClickedMessage(_viewModel.Entry is Illustration ? SimpleWorkType.IllustAndManga : SimpleWorkType.Novel, (string)((Button)sender).Content));
+        _ = WeakReferenceMessenger.Default.Send(new WorkTagClickedMessage(_viewModel.Entry is Illustration ? SimpleWorkType.IllustAndManga : SimpleWorkType.Novel, (string)((FrameworkElement)sender).Tag));
     }
 
     private async void IllustratorPersonPicture_OnClicked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
看到#362 关于标签翻译的建议
虽然目前可以通过悬停显示标签，但这种方式对用户不太友好（特别是触屏），遂将翻译直接显示到标签文字后
![image](https://github.com/user-attachments/assets/8fa472a4-507a-467d-bc9b-efbaee9d5249)


其他的一些更改
- 使用图标代替了文字描述
- 可以直接复制作品/作者ID（写了个Behavior）