### PR TITLE
更换登录使用的UserAgent以修复使用Webview登录时的403报错

### DIFF
--- a/src/Pixeval/Pages/Login/PixivAuth.cs
+++ b/src/Pixeval/Pages/Login/PixivAuth.cs
@@ -51,8 +51,8 @@ public static class PixivAuth
             var httpClient = App.AppViewModel.AppSettings.EnableDomainFronting
                 ? new HttpClient(new DelegatedHttpMessageHandler(MakoHttpOptions.CreateHttpMessageInvoker()))
                 : new();
-            httpClient.DefaultRequestHeaders.UserAgent.Add(new("PixivAndroidApp", "5.0.64"));
-            httpClient.DefaultRequestHeaders.UserAgent.Add(new("(Android 6.0)"));
+            httpClient.DefaultRequestHeaders.UserAgent.Add(new("PixivAndroidApp", "6.140.2"));
+            httpClient.DefaultRequestHeaders.UserAgent.Add(new("(Android 15.0)"));
             var scheme = App.AppViewModel.AppSettings.EnableDomainFronting ? "http" : "https";
 
             using var result = await httpClient.PostFormAsync(scheme + "://oauth.secure.pixiv.net/auth/token",


### PR DESCRIPTION
关联issue #716 

将原来的`PixivAndroidApp/5.0.64 (Android 6.0)`更换为`PixivAndroidApp/6.140.2 (Android 15.0)`(目前google play上的最新版的版本号)后，403报错消失，可以使用webview方式正常登录