### PR TITLE
添加作品方向筛选

### DIFF
--- a/src/Pixeval.Tests/WorkFilterEvaluatorTest.cs
+++ b/src/Pixeval.Tests/WorkFilterEvaluatorTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Mako.Global.Enum;
 using Mako.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Pixeval.Filters;
@@ -91,6 +92,39 @@ public sealed class WorkFilterEvaluatorTest
         AssertDoesNotMatch(work, "+r18");
         AssertDoesNotMatch(work, "+ai");
         AssertDoesNotMatch(work, "+gif");
+    }
+
+    [TestMethod]
+    public void OrientationFilterShouldMatchImageShape()
+    {
+        var landscape = CreateIllustration(
+            title: "Landscape",
+            author: "Alice",
+            tags: [],
+            totalBookmarks: 0,
+            createDate: DateTimeOffset.UtcNow,
+            width: 1200,
+            height: 600,
+            xRestrict: XRestrict.Ordinary,
+            aiType: AiType.NotAiGenerated,
+            illustrationType: IllustrationType.Illustration);
+        var portrait = landscape with { Width = 600, Height = 1200 };
+        var square = landscape with { Width = 800, Height = 800 };
+
+        Assert.IsTrue(WorkOrientationFilterEvaluator.Matches(landscape, SearchIllustrationRatioPattern.Landscape));
+        Assert.IsFalse(WorkOrientationFilterEvaluator.Matches(landscape, SearchIllustrationRatioPattern.Portrait));
+        Assert.IsTrue(WorkOrientationFilterEvaluator.Matches(portrait, SearchIllustrationRatioPattern.Portrait));
+        Assert.IsFalse(WorkOrientationFilterEvaluator.Matches(portrait, SearchIllustrationRatioPattern.Landscape));
+        Assert.IsTrue(WorkOrientationFilterEvaluator.Matches(square, SearchIllustrationRatioPattern.All));
+        Assert.IsFalse(WorkOrientationFilterEvaluator.Matches(square, SearchIllustrationRatioPattern.Landscape));
+        Assert.IsFalse(WorkOrientationFilterEvaluator.Matches(square, SearchIllustrationRatioPattern.Portrait));
+        Assert.IsTrue(WorkOrientationFilterEvaluator.Matches(square, SearchIllustrationRatioPattern.Square));
+
+        var missingSize = landscape with { Width = 0, Height = 0 };
+        Assert.IsTrue(WorkOrientationFilterEvaluator.Matches(missingSize, SearchIllustrationRatioPattern.All));
+        Assert.IsFalse(WorkOrientationFilterEvaluator.Matches(missingSize, SearchIllustrationRatioPattern.Landscape));
+        Assert.IsFalse(WorkOrientationFilterEvaluator.Matches(missingSize, SearchIllustrationRatioPattern.Portrait));
+        Assert.IsFalse(WorkOrientationFilterEvaluator.Matches(missingSize, SearchIllustrationRatioPattern.Square));
     }
 
     private static void AssertMatches(Illustration work, string text) =>

--- a/src/Pixeval.Tests/WorkFilterEvaluatorTest.cs
+++ b/src/Pixeval.Tests/WorkFilterEvaluatorTest.cs
@@ -111,6 +111,7 @@ public sealed class WorkFilterEvaluatorTest
         var portrait = landscape with { Width = 600, Height = 1200 };
         var square = landscape with { Width = 800, Height = 800 };
 
+        // 覆盖三种方向以及缺少尺寸时的筛选结果。
         Assert.IsTrue(WorkOrientationFilterEvaluator.Matches(landscape, SearchIllustrationRatioPattern.Landscape));
         Assert.IsFalse(WorkOrientationFilterEvaluator.Matches(landscape, SearchIllustrationRatioPattern.Portrait));
         Assert.IsTrue(WorkOrientationFilterEvaluator.Matches(portrait, SearchIllustrationRatioPattern.Portrait));

--- a/src/Pixeval/Models/Filters/WorkOrientationFilterEvaluator.cs
+++ b/src/Pixeval/Models/Filters/WorkOrientationFilterEvaluator.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Pixeval.
+// Licensed under the GPL-3.0 License.
+
+using Mako.Global.Enum;
+using Misaki;
+
+namespace Pixeval.Models.Filters;
+
+internal static class WorkOrientationFilterEvaluator
+{
+    public static bool Matches(IArtworkInfo entry, SearchIllustrationRatioPattern filter)
+    {
+        if (filter is SearchIllustrationRatioPattern.All)
+            return true;
+
+        if (entry is not IImageSize image || image.Width <= 0 || image.Height <= 0)
+            return false;
+
+        return filter switch
+        {
+            SearchIllustrationRatioPattern.Landscape => image.Width > image.Height,
+            SearchIllustrationRatioPattern.Portrait => image.Height > image.Width,
+            SearchIllustrationRatioPattern.Square => image.Width == image.Height,
+            _ => false
+        };
+    }
+}

--- a/src/Pixeval/Models/Filters/WorkOrientationFilterEvaluator.cs
+++ b/src/Pixeval/Models/Filters/WorkOrientationFilterEvaluator.cs
@@ -10,12 +10,15 @@ internal static class WorkOrientationFilterEvaluator
 {
     public static bool Matches(IArtworkInfo entry, SearchIllustrationRatioPattern filter)
     {
+        // “外观”表示不限制方向，直接保留所有作品。
         if (filter is SearchIllustrationRatioPattern.All)
             return true;
 
+        // 列表筛选只使用作品提供的主图尺寸；尺寸缺失时无法可靠判断方向。
         if (entry is not IImageSize image || image.Width <= 0 || image.Height <= 0)
             return false;
 
+        // 通过宽高比较区分横屏、竖屏和正方形。
         return filter switch
         {
             SearchIllustrationRatioPattern.Landscape => image.Width > image.Height,

--- a/src/Pixeval/Views/Work/WorkContainer.axaml
+++ b/src/Pixeval/Views/Work/WorkContainer.axaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:controls="using:Pixeval.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:enum="using:Mako.Global.Enum"
     xmlns:local="using:Pixeval"
     xmlns:markup="using:FluentIcons.Avalonia.Markup"
     xmlns:markup1="using:Pixeval.Views.Markup"
@@ -50,6 +51,12 @@
                     x:Name="SortOptionComboBox"
                     ItemsSource="{markup1:EnumResources x:TypeArguments=options:LocalSortOption}"
                     SelectionChanged="SortOptionComboBox_OnSelectionChanged" />
+                <controls:SymbolComboBox
+                    x:Name="OrientationFilterComboBox"
+                    IconMode="False"
+                    ItemsSource="{x:Static work:WorkContainer.OrientationFilterItems}"
+                    SelectedValue="{x:Static enum:SearchIllustrationRatioPattern.All}"
+                    SelectionChanged="OrientationFilterComboBox_OnSelectionChanged" />
                 <work:WorkFilterAutoSuggestBox
                     x:Name="WorkFilterAutoSuggestBox"
                     Width="250"

--- a/src/Pixeval/Views/Work/WorkContainer.axaml.cs
+++ b/src/Pixeval/Views/Work/WorkContainer.axaml.cs
@@ -18,6 +18,7 @@ using Misaki;
 using Pixeval.Collections;
 using Pixeval.Controls;
 using Pixeval.Filters.Analysis;
+using Pixeval.Filters.Nodes;
 using Pixeval.I18N;
 using Pixeval.Models.Filters;
 using Pixeval.Models.Options;
@@ -37,6 +38,14 @@ public partial class WorkContainer : UserControl
     private int _filterCompletionSourceCount = -1;
     private IReadOnlyList<FilterCompletionDefinition> _tagValueCompletions = [];
     private IReadOnlyList<FilterCompletionDefinition> _authorValueCompletions = [];
+    private FilterQuery? _filterQuery;
+
+    public static IReadOnlyList<SymbolComboBoxItem> OrientationFilterItems { get; } =
+    [
+        new(SearchIllustrationRatioPattern.All, I18NManager.GetResource(WorkContainerResources.OrientationFilter.All), default),
+        new(SearchIllustrationRatioPattern.Landscape, I18NManager.GetResource(WorkContainerResources.OrientationFilter.Landscape), default),
+        new(SearchIllustrationRatioPattern.Portrait, I18NManager.GetResource(WorkContainerResources.OrientationFilter.Portrait), default)
+    ];
 
     public static readonly DirectProperty<WorkContainer, bool> IsRefreshEnabledProperty = AvaloniaProperty.RegisterDirect<WorkContainer, bool>(
         nameof(IsRefreshEnabled),
@@ -120,11 +129,15 @@ public partial class WorkContainer : UserControl
 
     private void SortOptionComboBox_OnSelectionChanged(SymbolComboBox sender, EventArgs e) => SetSortOption();
 
+    private void OrientationFilterComboBox_OnSelectionChanged(SymbolComboBox sender, EventArgs e) => ApplyFilter();
+
     private void WorkView_OnDataContextChanged(object? sender, EventArgs args)
     {
         DataContext = (sender as Control)?.DataContext;
+        _filterQuery = null;
         ResetFilterValueCompletions();
         SetSortOption();
+        ApplyFilter();
     }
 
     public void SetSortOption()
@@ -255,7 +268,8 @@ public partial class WorkContainer : UserControl
 
         if (string.IsNullOrWhiteSpace(text))
         {
-            viewModel.UserFilter = null;
+            _filterQuery = null;
+            ApplyFilter();
             WorkFilterAutoSuggestBox.ClearSelection();
             WorkFilterAutoSuggestBox.RefreshCompletions();
             return;
@@ -276,10 +290,27 @@ public partial class WorkContainer : UserControl
             return;
         }
 
-        viewModel.UserFilter = query.HasPredicates
-            ? IFilter<IWorkViewModel>.Create(o => o.Filter(query.Root), false)
-            : null;
+        _filterQuery = query.HasPredicates ? query : null;
+        ApplyFilter();
         WorkFilterAutoSuggestBox.ClearSelection();
+    }
+
+    private void ApplyFilter()
+    {
+        if (DataContext is not IOperableViewViewModel viewModel)
+            return;
+
+        var orientation = OrientationFilterComboBox.SelectedValue is SearchIllustrationRatioPattern value
+            ? value
+            : SearchIllustrationRatioPattern.All;
+        var query = _filterQuery;
+
+        viewModel.UserFilter = query is null && orientation is SearchIllustrationRatioPattern.All
+            ? null
+            : IFilter<IWorkViewModel>.Create(work =>
+                (query is null || work.Filter(query.Root))
+                && WorkOrientationFilterEvaluator.Matches(work.Entry, orientation),
+                false);
     }
 
     private FilterAnalysisResult AnalyzeFilter(string? text, int caret)

--- a/src/Pixeval/Views/Work/WorkContainer.axaml.cs
+++ b/src/Pixeval/Views/Work/WorkContainer.axaml.cs
@@ -40,6 +40,7 @@ public partial class WorkContainer : UserControl
     private IReadOnlyList<FilterCompletionDefinition> _authorValueCompletions = [];
     private FilterQuery? _filterQuery;
 
+    // 方向下拉项共用本地化资源，确保显示文本随当前语言切换。
     public static IReadOnlyList<SymbolComboBoxItem> OrientationFilterItems { get; } =
     [
         new(SearchIllustrationRatioPattern.All, I18NManager.GetResource(WorkContainerResources.OrientationFilter.All), default),
@@ -305,6 +306,7 @@ public partial class WorkContainer : UserControl
             : SearchIllustrationRatioPattern.All;
         var query = _filterQuery;
 
+        // 文本筛选和方向筛选合并为同一个条件，切换任一筛选项都不会覆盖另一项。
         viewModel.UserFilter = query is null && orientation is SearchIllustrationRatioPattern.All
             ? null
             : IFilter<IWorkViewModel>.Create(work =>

--- a/src/Pixeval/i18n/Language.cs
+++ b/src/Pixeval/i18n/Language.cs
@@ -1683,6 +1683,12 @@ namespace Pixeval
         {
             public const string PlaceholderText = "WorkContainer.FilterAutoSuggestBox.PlaceholderText";
         }
+        public static class OrientationFilter
+        {
+            public const string All = "WorkContainer.OrientationFilter.All";
+            public const string Landscape = "WorkContainer.OrientationFilter.Landscape";
+            public const string Portrait = "WorkContainer.OrientationFilter.Portrait";
+        }
         public static class RefreshButton
         {
             public const string Label = "WorkContainer.RefreshButton.Label";

--- a/src/Pixeval/i18n/ru-RU/WorkContainer.json
+++ b/src/Pixeval/i18n/ru-RU/WorkContainer.json
@@ -23,5 +23,10 @@
   "DownloadItemsQueuedFormatted": "Добавлено работ в очередь скачивания: {0}",
   "FilterAutoSuggestBox": {
     "PlaceholderText": "Фильтр работ (см. справку)"
+  },
+  "OrientationFilter": {
+    "All": "Все",
+    "Landscape": "Альбомная",
+    "Portrait": "Портретная"
   }
 }

--- a/src/Pixeval/i18n/zh-Hans/WorkContainer.json
+++ b/src/Pixeval/i18n/zh-Hans/WorkContainer.json
@@ -25,7 +25,7 @@
     "PlaceholderText": "筛选作品（用法见帮助页）"
   },
   "OrientationFilter": {
-    "All": "全部",
+    "All": "外观",
     "Landscape": "横屏",
     "Portrait": "竖屏"
   }

--- a/src/Pixeval/i18n/zh-Hans/WorkContainer.json
+++ b/src/Pixeval/i18n/zh-Hans/WorkContainer.json
@@ -23,5 +23,10 @@
   "DownloadItemsQueuedFormatted": "已将 {0} 个作品添加至下载列表",
   "FilterAutoSuggestBox": {
     "PlaceholderText": "筛选作品（用法见帮助页）"
+  },
+  "OrientationFilter": {
+    "All": "全部",
+    "Landscape": "横屏",
+    "Portrait": "竖屏"
   }
 }


### PR DESCRIPTION
## 变更

- 在作品列表添加外观、横屏、竖屏筛选。
- 保留文本筛选与方向筛选的组合行为。
- 将中文菜单文案从“全部”改为“外观”。
- 增加方向筛选回归测试和中文注释。

## 验证

- `Pixeval.Tests.exe`：166 个测试，165 个通过，1 个因缺少扩展原生库跳过。
- `Pixeval.Desktop` 构建：0 个错误；已有 136 个本地化/XAML 警告。

本 PR 仅包含方向筛选相关的 7 个功能、测试和本地化文件，不包含 AI 文档或其他文档改动。
