### PR TITLE
fix: cache优化，防止频繁调用EnumerateCacheFiles

### DIFF
--- a/src/Pixeval.Tests/FileCacheTest.cs
+++ b/src/Pixeval.Tests/FileCacheTest.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Pixeval.Utilities.IO.Caching;
 
@@ -8,7 +9,7 @@ namespace Pixeval.Tests;
 public sealed class FileCacheTest
 {
     [TestMethod]
-    public void UnavailableCacheDirectoryShouldDegradeToFailure()
+    public async Task UnavailableCacheDirectoryShouldDegradeToFailure()
     {
         var cachePath = Path.GetTempFileName();
         try
@@ -19,8 +20,8 @@ public sealed class FileCacheTest
             Assert.IsNull(cache.TryOpen("key"));
             Assert.AreEqual(FileCacheWriteResult.Failed, cache.TryCache("key", source, null));
 
-            cache.EnforceSizeLimit(1);
-            cache.Purge();
+            await cache.EnforceSizeLimitAsync(1);
+            await cache.PurgeAsync();
         }
         finally
         {

--- a/src/Pixeval/AppManagement/AppViewModel.cs
+++ b/src/Pixeval/AppManagement/AppViewModel.cs
@@ -67,7 +67,7 @@ public sealed class AppViewModel(App app, FileLogger logger) : IAsyncDisposable
         SetNameResolvers();
         // 触发卸载插件
         _ = AppServiceProvider.GetRequiredService<ExtensionService>();
-        CacheHelper.EnforceCacheSizeLimit();
+        _ = CacheHelper.EnforceCacheSizeLimitAsync();
     }
 
     private ServiceProvider CreateServiceProvider()

--- a/src/Pixeval/Utilities/IO/Caching/CacheHelper.cs
+++ b/src/Pixeval/Utilities/IO/Caching/CacheHelper.cs
@@ -32,15 +32,15 @@ public static class CacheHelper
     public static readonly Lazy<IAnimatedBitmap> AnimatedImageNotAvailable =
         new(() => IAnimatedBitmap.Load([WrappedImageNotAvailable.Value], [100]));
 
-    public static void PurgeCache() => _FileCache.Purge();
+    public static Task PurgeCacheAsync(CancellationToken token = default) => _FileCache.PurgeAsync(token);
 
-    public static void EnforceCacheSizeLimit()
+    public static Task EnforceCacheSizeLimitAsync(CancellationToken token = default)
     {
         var settings = App.AppViewModel.AppSettings.ApplicationSettings;
         if (!settings.LimitFileCacheSize)
-            return;
+            return Task.CompletedTask;
 
-        _FileCache.EnforceSizeLimit(GetCacheSizeLimitInBytes());
+        return _FileCache.EnforceSizeLimitAsync(GetCacheSizeLimitInBytes(), token);
     }
 
     private static long GetCacheSizeLimitInBytes()

--- a/src/Pixeval/Utilities/IO/Caching/FileCache.cs
+++ b/src/Pixeval/Utilities/IO/Caching/FileCache.cs
@@ -55,6 +55,9 @@ internal sealed class FileCache(string cacheDirectory)
         if (!TryEnsureCacheDirectory())
             return FileCacheWriteResult.Failed;
 
+        // 确保计数器初始化完成，避免重复计数（问题3）
+        EnsureSizeInitialized();
+
         try
         {
             var path = GetCacheFilePath(key);
@@ -116,22 +119,29 @@ internal sealed class FileCache(string cacheDirectory)
     {
         try
         {
-            if (!Directory.Exists(CacheDirectory))
+            lock (_sizeInitLock)
             {
+                // 重置计数器并标记未初始化，保证后续重新扫描
+                _sizeInitialized = false;
+                _totalCacheSize = 0;
+
+                if (!Directory.Exists(CacheDirectory))
+                {
+                    _ = FileHelper.TryCreateDirectory(CacheDirectory);
+                    return;
+                }
+
+                var files = FileHelper.EnumerateFiles(CacheDirectory);
+                var directories = FileHelper.EnumerateDirectories(CacheDirectory);
+
+                foreach (var file in files)
+                    _ = FileHelper.TryDeleteFile(file);
+
+                foreach (var directory in directories)
+                    _ = FileHelper.TryDeleteDirectory(directory);
+
                 _ = FileHelper.TryCreateDirectory(CacheDirectory);
-                return;
             }
-
-            var files = FileHelper.EnumerateFiles(CacheDirectory);
-            var directories = FileHelper.EnumerateDirectories(CacheDirectory);
-
-            foreach (var file in files)
-                _ = FileHelper.TryDeleteFile(file);
-
-            foreach (var directory in directories)
-                _ = FileHelper.TryDeleteDirectory(directory);
-
-            _ = FileHelper.TryCreateDirectory(CacheDirectory);
         }
         catch
         {
@@ -148,27 +158,47 @@ internal sealed class FileCache(string cacheDirectory)
         if (Interlocked.Read(ref _totalCacheSize) <= maxBytes)
             return;
 
-        try
+        // 使用锁防止并发淘汰，保证计数器更新原子性
+        lock (_sizeInitLock)
         {
-            var files = EnumerateCacheFiles().ToArray();
-            var totalBytes = files.Sum(static file => file.Length);
-            if (totalBytes <= maxBytes)
+            // 双重检查，避免其他线程已执行淘汰
+            if (Interlocked.Read(ref _totalCacheSize) <= maxBytes)
                 return;
 
-            foreach (var file in files.OrderBy(static file => file.LastAccessTimeUtc)
-                         .ThenBy(static file => file.LastWriteTimeUtc))
+            // 收集缓存文件信息快照，避免后续访问 FileInfo 时文件被删除导致异常
+            var fileInfos = new List<(string path, long length, DateTime lastAccess, DateTime lastWrite)>();
+            foreach (var filePath in FileHelper.EnumerateFiles(CacheDirectory, $"*{CacheFileExtension}"))
             {
-                if (totalBytes <= maxBytes)
-                    return;
-
-                var length = file.Length;
-                if (FileHelper.TryDeleteFile(file.FullName))
-                    totalBytes -= length;
+                try
+                {
+                    var fi = new FileInfo(filePath);
+                    if (fi.Exists)
+                    {
+                        fileInfos.Add((fi.FullName, fi.Length, fi.LastAccessTimeUtc, fi.LastWriteTimeUtc));
+                    }
+                }
+                catch
+                {
+                    // 忽略已删除或无法访问的文件
+                }
             }
-        }
-        catch
-        {
-            // Cache eviction must not affect image loading or app startup.
+
+            var currentTotal = Interlocked.Read(ref _totalCacheSize);
+            if (currentTotal <= maxBytes)
+                return;
+
+            // 按最后访问时间升序淘汰（最早访问的最先被删除）
+            foreach (var item in fileInfos.OrderBy(i => i.lastAccess).ThenBy(i => i.lastWrite))
+            {
+                if (currentTotal <= maxBytes)
+                    break;
+
+                if (FileHelper.TryDeleteFile(item.path))
+                {
+                    currentTotal -= item.length;
+                    Interlocked.Add(ref _totalCacheSize, -item.length);  // 同步扣减全局计数器
+                }
+            }
         }
     }
     
@@ -178,7 +208,23 @@ internal sealed class FileCache(string cacheDirectory)
         lock (_sizeInitLock)
         {
             if (_sizeInitialized) return;
-            _totalCacheSize = EnumerateCacheFiles().Sum(f => f.Length);
+
+            long total = 0;
+            foreach (var filePath in FileHelper.EnumerateFiles(CacheDirectory, $"*{CacheFileExtension}"))
+            {
+                try
+                {
+                    var fi = new FileInfo(filePath);
+                    if (fi.Exists)
+                        total += fi.Length;
+                }
+                catch
+                {
+                    // 文件可能在枚举过程中被删除，忽略该文件
+                }
+            }
+
+            _totalCacheSize = total;
             _sizeInitialized = true;
         }
     }

--- a/src/Pixeval/Utilities/IO/Caching/FileCache.cs
+++ b/src/Pixeval/Utilities/IO/Caching/FileCache.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Pixeval.Utilities.IO.Caching;
 
@@ -17,10 +18,12 @@ internal sealed class FileCache(string cacheDirectory)
     private const string TempFileExtension = ".tmp";
     private const int CacheCopyBufferSize = 81920;
     private const int CacheFileLockCount = 64;
-    
+
     private long _totalCacheSize;
     private bool _sizeInitialized;
-    private readonly object _sizeInitLock = new();
+    private bool _cacheMaintenanceInProgress;
+    private readonly Lock _cacheStateLock = new();
+    private readonly SemaphoreSlim _cacheMaintenanceSemaphore = new(1, 1);
 
     private readonly Lock[] _cacheFileLocks =
         [.. Enumerable.Repeat(0, CacheFileLockCount).Select(static _ => new Lock())];
@@ -55,8 +58,11 @@ internal sealed class FileCache(string cacheDirectory)
         if (!TryEnsureCacheDirectory())
             return FileCacheWriteResult.Failed;
 
-        // 确保计数器初始化完成，避免重复计数（问题3）
-        EnsureSizeInitialized();
+        lock (_cacheStateLock)
+        {
+            if (_cacheMaintenanceInProgress)
+                return FileCacheWriteResult.Failed;
+        }
 
         try
         {
@@ -88,11 +94,29 @@ internal sealed class FileCache(string cacheDirectory)
                     _ = FileHelper.TryTouchFile(tempPath, DateTime.UtcNow);
                     var fileInfo = new FileInfo(tempPath);
                     var fileSize = fileInfo.Length;
-                    FileHelper.Move(tempPath, path);
-                    Interlocked.Add(ref _totalCacheSize, fileSize);
+
+                    lock (_cacheStateLock)
+                    {
+                        if (_cacheMaintenanceInProgress)
+                        {
+                            _ = FileHelper.TryDeleteFile(tempPath);
+                            return FileCacheWriteResult.Failed;
+                        }
+
+                        if (File.Exists(path))
+                        {
+                            _ = FileHelper.TryDeleteFile(tempPath);
+                            _ = FileHelper.TryTouchFile(path);
+                            return FileCacheWriteResult.Success;
+                        }
+
+                        FileHelper.Move(tempPath, path);
+                        if (_sizeInitialized)
+                            _totalCacheSize += fileSize;
+                    }
 
                     if (sizeLimitBytes is { } maxBytes)
-                        EnforceSizeLimit(maxBytes);
+                        _ = EnforceSizeLimitAsync(maxBytes);
 
                     return FileCacheWriteResult.Success;
                 }
@@ -100,6 +124,8 @@ internal sealed class FileCache(string cacheDirectory)
                 {
                     _ = FileHelper.TryDeleteFile(tempPath);
                     _ = FileHelper.TryTouchFile(path);
+                    lock (_cacheStateLock)
+                        _sizeInitialized = false;
                     return FileCacheWriteResult.Success;
                 }
                 catch
@@ -115,117 +141,110 @@ internal sealed class FileCache(string cacheDirectory)
         }
     }
 
-    public void Purge()
+    public Task PurgeAsync(CancellationToken token = default) =>
+        RunCacheMaintenanceAsync(Purge, token);
+
+    private void Purge()
     {
         try
         {
-            lock (_sizeInitLock)
+            if (!Directory.Exists(CacheDirectory))
             {
-                // 重置计数器并标记未初始化，保证后续重新扫描
-                _sizeInitialized = false;
-                _totalCacheSize = 0;
-
-                if (!Directory.Exists(CacheDirectory))
-                {
-                    _ = FileHelper.TryCreateDirectory(CacheDirectory);
-                    return;
-                }
-
-                var files = FileHelper.EnumerateFiles(CacheDirectory);
-                var directories = FileHelper.EnumerateDirectories(CacheDirectory);
-
-                foreach (var file in files)
-                    _ = FileHelper.TryDeleteFile(file);
-
-                foreach (var directory in directories)
-                    _ = FileHelper.TryDeleteDirectory(directory);
-
                 _ = FileHelper.TryCreateDirectory(CacheDirectory);
+                return;
             }
+
+            var files = FileHelper.EnumerateFiles(CacheDirectory).ToArray();
+            var directories = FileHelper.EnumerateDirectories(CacheDirectory).ToArray();
+
+            foreach (var file in files)
+                _ = FileHelper.TryDeleteFile(file);
+
+            foreach (var directory in directories)
+                _ = FileHelper.TryDeleteDirectory(directory);
+
+            _ = FileHelper.TryCreateDirectory(CacheDirectory);
         }
         catch
         {
             // Cache cleanup is best effort.
         }
-    }
-
-    public void EnforceSizeLimit(long maxBytes)
-    {
-        if (!TryEnsureCacheDirectory())
-            return;
-        
-        EnsureSizeInitialized();
-        if (Interlocked.Read(ref _totalCacheSize) <= maxBytes)
-            return;
-
-        // 使用锁防止并发淘汰，保证计数器更新原子性
-        lock (_sizeInitLock)
+        finally
         {
-            // 双重检查，避免其他线程已执行淘汰
-            if (Interlocked.Read(ref _totalCacheSize) <= maxBytes)
-                return;
-
-            // 收集缓存文件信息快照，避免后续访问 FileInfo 时文件被删除导致异常
-            var fileInfos = new List<(string path, long length, DateTime lastAccess, DateTime lastWrite)>();
-            foreach (var filePath in FileHelper.EnumerateFiles(CacheDirectory, $"*{CacheFileExtension}"))
+            lock (_cacheStateLock)
             {
-                try
-                {
-                    var fi = new FileInfo(filePath);
-                    if (fi.Exists)
-                    {
-                        fileInfos.Add((fi.FullName, fi.Length, fi.LastAccessTimeUtc, fi.LastWriteTimeUtc));
-                    }
-                }
-                catch
-                {
-                    // 忽略已删除或无法访问的文件
-                }
-            }
-
-            var currentTotal = Interlocked.Read(ref _totalCacheSize);
-            if (currentTotal <= maxBytes)
-                return;
-
-            // 按最后访问时间升序淘汰（最早访问的最先被删除）
-            foreach (var item in fileInfos.OrderBy(i => i.lastAccess).ThenBy(i => i.lastWrite))
-            {
-                if (currentTotal <= maxBytes)
-                    break;
-
-                if (FileHelper.TryDeleteFile(item.path))
-                {
-                    currentTotal -= item.length;
-                    Interlocked.Add(ref _totalCacheSize, -item.length);  // 同步扣减全局计数器
-                }
+                _sizeInitialized = false;
+                _totalCacheSize = 0;
             }
         }
     }
-    
-    private void EnsureSizeInitialized()
-    {
-        if (_sizeInitialized) return;
-        lock (_sizeInitLock)
-        {
-            if (_sizeInitialized) return;
 
-            long total = 0;
-            foreach (var filePath in FileHelper.EnumerateFiles(CacheDirectory, $"*{CacheFileExtension}"))
+    public Task EnforceSizeLimitAsync(long maxBytes, CancellationToken token = default) =>
+        RunCacheMaintenanceAsync(() => EnforceSizeLimit(maxBytes), token);
+
+    private void EnforceSizeLimit(long maxBytes)
+    {
+        if (!TryEnsureCacheDirectory())
+            return;
+
+        try
+        {
+            var fileInfos = new List<(string Path, long Length, DateTime LastAccess, DateTime LastWrite)>();
+            if (!TryEnumerateCacheFiles(out var filePaths))
+                return;
+
+            foreach (var filePath in filePaths)
             {
                 try
                 {
-                    var fi = new FileInfo(filePath);
-                    if (fi.Exists)
-                        total += fi.Length;
+                    var fileInfo = new FileInfo(filePath);
+                    if (fileInfo.Exists)
+                        fileInfos.Add((fileInfo.FullName, fileInfo.Length, fileInfo.LastAccessTimeUtc,
+                            fileInfo.LastWriteTimeUtc));
                 }
                 catch
                 {
-                    // 文件可能在枚举过程中被删除，忽略该文件
+                    // The cache is best effort; ignore files that disappear during inspection.
                 }
             }
 
-            _totalCacheSize = total;
-            _sizeInitialized = true;
+            var currentTotal = fileInfos.Sum(static file => file.Length);
+            if (currentTotal > maxBytes)
+            {
+                foreach (var file in fileInfos.OrderBy(static file => file.LastAccess)
+                             .ThenBy(static file => file.LastWrite))
+                {
+                    if (currentTotal <= maxBytes)
+                        break;
+
+                    if (FileHelper.TryDeleteFile(file.Path))
+                        currentTotal -= file.Length;
+                }
+            }
+
+            lock (_cacheStateLock)
+            {
+                _totalCacheSize = currentTotal;
+                _sizeInitialized = true;
+            }
+        }
+        catch
+        {
+            // Cache eviction must not affect image loading or app startup.
+        }
+    }
+
+    private bool TryEnumerateCacheFiles(out IReadOnlyList<string> filePaths)
+    {
+        try
+        {
+            filePaths = Directory.GetFiles(CacheDirectory, $"*{CacheFileExtension}", SearchOption.TopDirectoryOnly);
+            return true;
+        }
+        catch
+        {
+            filePaths = [];
+            return false;
         }
     }
 
@@ -248,10 +267,26 @@ internal sealed class FileCache(string cacheDirectory)
         return true;
     }
 
-    private IEnumerable<FileInfo> EnumerateCacheFiles() =>
-        FileHelper.EnumerateFiles(CacheDirectory, $"*{CacheFileExtension}")
-            .Select(static file => new FileInfo(file))
-            .Where(static file => file.Exists);
+    private async Task RunCacheMaintenanceAsync(Action action, CancellationToken token)
+    {
+        await _cacheMaintenanceSemaphore.WaitAsync(token).ConfigureAwait(false);
+        try
+        {
+            lock (_cacheStateLock)
+            {
+                _cacheMaintenanceInProgress = true;
+                _sizeInitialized = false;
+            }
+
+            await Task.Run(action, token).ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_cacheStateLock)
+                _cacheMaintenanceInProgress = false;
+            _cacheMaintenanceSemaphore.Release();
+        }
+    }
 
     private string GetCacheFilePath(string key)
     {

--- a/src/Pixeval/Utilities/IO/Caching/FileCache.cs
+++ b/src/Pixeval/Utilities/IO/Caching/FileCache.cs
@@ -17,6 +17,10 @@ internal sealed class FileCache(string cacheDirectory)
     private const string TempFileExtension = ".tmp";
     private const int CacheCopyBufferSize = 81920;
     private const int CacheFileLockCount = 64;
+    
+    private long _totalCacheSize;
+    private bool _sizeInitialized;
+    private readonly object _sizeInitLock = new();
 
     private readonly Lock[] _cacheFileLocks =
         [.. Enumerable.Repeat(0, CacheFileLockCount).Select(static _ => new Lock())];
@@ -79,7 +83,10 @@ internal sealed class FileCache(string cacheDirectory)
                     }
 
                     _ = FileHelper.TryTouchFile(tempPath, DateTime.UtcNow);
+                    var fileInfo = new FileInfo(tempPath);
+                    var fileSize = fileInfo.Length;
                     FileHelper.Move(tempPath, path);
+                    Interlocked.Add(ref _totalCacheSize, fileSize);
 
                     if (sizeLimitBytes is { } maxBytes)
                         EnforceSizeLimit(maxBytes);
@@ -136,6 +143,10 @@ internal sealed class FileCache(string cacheDirectory)
     {
         if (!TryEnsureCacheDirectory())
             return;
+        
+        EnsureSizeInitialized();
+        if (Interlocked.Read(ref _totalCacheSize) <= maxBytes)
+            return;
 
         try
         {
@@ -158,6 +169,17 @@ internal sealed class FileCache(string cacheDirectory)
         catch
         {
             // Cache eviction must not affect image loading or app startup.
+        }
+    }
+    
+    private void EnsureSizeInitialized()
+    {
+        if (_sizeInitialized) return;
+        lock (_sizeInitLock)
+        {
+            if (_sizeInitialized) return;
+            _totalCacheSize = EnumerateCacheFiles().Sum(f => f.Length);
+            _sizeInitialized = true;
         }
     }
 

--- a/src/Pixeval/ViewModels/SettingsPageViewModel.cs
+++ b/src/Pixeval/ViewModels/SettingsPageViewModel.cs
@@ -60,11 +60,11 @@ public class SettingsPageViewModel : ViewModelBase
                 .Bool(t => t.UseFileCache)
                 .MultiValuesWithSwitch(t => t.LimitFileCacheSize,
                     entry => entry.Int(t => t.FileCacheSizeLimitInMegabytes, 1, 0x100000, 0x80,
-                        t => t.ValueChanged += _ => CacheHelper.EnforceCacheSizeLimit()),
+                        t => t.ValueChanged += _value => _ = CacheHelper.EnforceCacheSizeLimitAsync()),
                     t => t.MainValue.ValueChanged += enabled =>
                     {
                         if (enabled)
-                            CacheHelper.EnforceCacheSizeLimit();
+                            _ = CacheHelper.EnforceCacheSizeLimitAsync();
                     })
                 .Int(t => t.HomePageRows, 1, 12, 1)
                 .Int(t => t.HomePageColumns, 1, 12, 1)

--- a/src/Pixeval/Views/Settings/SettingsMainView.axaml.cs
+++ b/src/Pixeval/Views/Settings/SettingsMainView.axaml.cs
@@ -189,9 +189,9 @@ public partial class SettingsMainView : ContentPage
         }
     }
 
-    private void DeleteFileCacheEntryButton_OnClicked(object sender, RoutedEventArgs e)
+    private async void DeleteFileCacheEntryButton_OnClicked(object sender, RoutedEventArgs e)
     {
-        CacheHelper.PurgeCache();
+        await CacheHelper.PurgeCacheAsync();
         ShowClearData(ClearDataKind.FileCache);
     }
 


### PR DESCRIPTION
分析显示，EnumerateCacheFiles为性能热点，此PR优化减少了EnumerateCacheFiles的调用，可以减少浏览时的卡顿