### PR TITLE
docs: deprecate homebrew formula support for linux hosts

### DIFF
--- a/.github/README.en.md
+++ b/.github/README.en.md
@@ -42,7 +42,7 @@ For more information, go to the [Project Homepage](https://pixeval.github.io/)
 
 [![brew test-bot](https://github.com/Pixeval/homebrew-tap/actions/workflows/tests.yml/badge.svg)](https://github.com/Pixeval/homebrew-tap/actions/workflows/tests.yml)
 
-Pixeval offers a self-hosted [Homebrew Tap](https://github.com/Pixeval/homebrew-tap) for installing Pixeval on Mac and Linux. For installation and uninstallation instructions, see [Homebrew](https://github.com/Pixeval/homebrew-tap#install).
+Pixeval offers a self-hosted [Homebrew Tap](https://github.com/Pixeval/homebrew-tap) for installing Pixeval on Mac. For installation and uninstallation instructions, see [Tap Repository](https://github.com/Pixeval/homebrew-tap#install).
 
 ## In case that you are having problems... (Ordered by recommend priority)
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -41,7 +41,7 @@
 
 [![brew test-bot](https://github.com/Pixeval/homebrew-tap/actions/workflows/tests.yml/badge.svg)](https://github.com/Pixeval/homebrew-tap/actions/workflows/tests.yml)
 
-Pixeval 提供自托管的 [Homebrew Tap](https://github.com/Pixeval/homebrew-tap) 在 Mac 和 Linux 上安装 Pixeval，安装和卸载方法参见 [homebrew](https://github.com/Pixeval/homebrew-tap#install)。
+Pixeval 提供自托管的 [Homebrew Tap](https://github.com/Pixeval/homebrew-tap) 在 Mac 上安装 Pixeval，安装和卸载方法参见 [tap 仓库](https://github.com/Pixeval/homebrew-tap#install)。
 
 ## 反馈问题（按照推荐程度优先级排序）
 


### PR DESCRIPTION
新版的asset发行方式发生了变化，不再有为linux主机提供.tar.gz
考虑到：
1. 为linux主机维护formula过于麻烦，不稳定
2. linux上formula更适合命令行的app
3. source code构建麻烦，还不如直接下载.appImage方便
4. 用户少，不易更新
5. 新的发行覆盖同一个major版本的旧asset，导致过时的formula完全不可用（旧.tar.gz被新.tar.gz立即覆盖）
因此于2026-08-22停用formula（5.0.10版本），对文档进行修改
Tap仓库已经更新，badge暂时显示失败状态

猜你想看：
https://github.com/Pixeval/homebrew-tap/pull/24