### PR TITLE
feat: 侧边栏折叠功能

### DIFF
--- a/src/Pixeval/Controls/CollapsibleNavigationSidebar.axaml
+++ b/src/Pixeval/Controls/CollapsibleNavigationSidebar.axaml
@@ -1,0 +1,29 @@
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:Pixeval.Controls">
+    <ControlTheme x:Key="{x:Type controls:CollapsibleNavigationSidebar}"
+                  TargetType="{x:Type controls:CollapsibleNavigationSidebar}">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <DockPanel>
+                    <Border x:Name="PART_MoreButtonHost"
+                            DockPanel.Dock="Bottom"
+                            Height="40"
+                            Margin="5,0,5,5"
+                            IsVisible="False">
+                        <Button x:Name="PART_MoreButton"
+                                HorizontalAlignment="Stretch"
+                                Background="Transparent"
+                                BorderThickness="0">
+                            <Grid>
+                                <TextBlock Text="更多" />
+                            </Grid>
+                        </Button>
+                    </Border>
+                    <ItemsPresenter x:Name="PART_ItemsPresenter" />
+                </DockPanel>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+</ResourceDictionary>
+

--- a/src/Pixeval/Controls/CollapsibleNavigationSidebar.axaml.cs
+++ b/src/Pixeval/Controls/CollapsibleNavigationSidebar.axaml.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+namespace Pixeval.Controls;
+
+public class CollapsibleNavigationSidebar : ItemsControl
+{
+    private Button _moreButton;
+    private Border _moreButtonHost;
+    private MenuFlyout _moreFlyout;
+    private readonly List<Control> _itemContainers = new();
+
+    public static readonly StyledProperty<IEnumerable> HeaderItemsProperty =
+        AvaloniaProperty.Register<CollapsibleNavigationSidebar, IEnumerable>(nameof(HeaderItems));
+
+    public static readonly StyledProperty<IEnumerable> FooterItemsProperty =
+        AvaloniaProperty.Register<CollapsibleNavigationSidebar, IEnumerable>(nameof(FooterItems));
+
+    public IEnumerable HeaderItems
+    {
+        get => GetValue(HeaderItemsProperty);
+        set => SetValue(HeaderItemsProperty, value);
+    }
+
+    public IEnumerable FooterItems
+    {
+        get => GetValue(FooterItemsProperty);
+        set => SetValue(FooterItemsProperty, value);
+    }
+
+    static CollapsibleNavigationSidebar()
+    {
+        HeaderItemsProperty.Changed.AddClassHandler<CollapsibleNavigationSidebar>((s, e) => s.UpdateItems());
+        FooterItemsProperty.Changed.AddClassHandler<CollapsibleNavigationSidebar>((s, e) => s.UpdateItems());
+    }
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+        _moreButtonHost = e.NameScope.Get<Border>("PART_MoreButtonHost");
+        _moreButton = e.NameScope.Get<Button>("PART_MoreButton");
+        _moreFlyout = new MenuFlyout { Placement = PlacementMode.TopEdgeAlignedLeft };
+        _moreButton.Flyout = _moreFlyout;
+        _moreButton.Click += OnMoreButtonClick;
+        _moreButtonHost.IsVisible = false;
+        this.SizeChanged += OnSizeChanged;
+    }
+
+    private void OnSizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        UpdateVisibility(e.NewSize.Height);
+    }
+
+    private void UpdateItems()
+    {
+        var combined = new List<object>();
+        if (HeaderItems != null) combined.AddRange(HeaderItems.Cast<object>());
+        if (FooterItems != null) combined.AddRange(FooterItems.Cast<object>());
+        ItemsSource = combined;
+        _itemContainers.Clear();
+        InvalidateMeasure();
+        Dispatcher.UIThread.Post(() => UpdateVisibility(Bounds.Height), DispatcherPriority.Loaded);
+    }
+
+    private void UpdateVisibility(double availableHeight)
+    {
+        if (Items.Count == 0 || availableHeight <= 0) return;
+
+        var containers = new List<Control>();
+        for (int i = 0; i < Items.Count; i++)
+        {
+            if (this.ContainerFromIndex(i) is Control c)
+                containers.Add(c);
+        }
+
+        if (containers.Count != _itemContainers.Count)
+        {
+            _itemContainers.Clear();
+            _itemContainers.AddRange(containers);
+        }
+
+        if (_itemContainers.Count == 0) return;
+
+        double reservedHeight = 50;
+        double totalHeight = 0;
+        int visibleCount = 0;
+
+        foreach (var container in _itemContainers)
+        {
+            if (container.DesiredSize.Height <= 0)
+                container.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+        }
+
+        for (int i = 0; i < _itemContainers.Count; i++)
+        {
+            double h = _itemContainers[i].DesiredSize.Height > 0 ? _itemContainers[i].DesiredSize.Height : 40;
+            if (totalHeight + h + reservedHeight <= availableHeight)
+            {
+                totalHeight += h;
+                visibleCount++;
+            }
+            else break;
+        }
+
+        bool hasMore = visibleCount < _itemContainers.Count;
+
+        for (int i = 0; i < _itemContainers.Count; i++)
+            _itemContainers[i].IsVisible = i < visibleCount;
+
+        _moreButtonHost.IsVisible = hasMore;
+        _moreFlyout.ItemsSource = hasMore ? _itemContainers.Skip(visibleCount).Select(c => c.DataContext).ToList() : null;
+    }
+
+    private void OnMoreButtonClick(object sender, RoutedEventArgs e)
+    {
+        _moreFlyout.ShowAt(_moreButton);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        if (change.Property == ItemsSourceProperty && change.NewValue != null)
+            Dispatcher.UIThread.Post(() => UpdateVisibility(Bounds.Height), DispatcherPriority.Loaded);
+        base.OnPropertyChanged(change);
+    }
+}

--- a/src/Pixeval/Views/ViewContainers/TabViewContainer.axaml
+++ b/src/Pixeval/Views/ViewContainers/TabViewContainer.axaml
@@ -90,7 +90,6 @@
                                 IsEnabled="{Binding IsLoggedIn, Source={x:Static views:PixevalSettings.Instance}}"
                                 Tag="{Binding Url}" />
                             <Separator />
-                            <!--  该项不显示  -->
                             <MenuItem
                                 Command="{Binding ToggleRestrictedModeCommand, Mode=OneTime}"
                                 Header="{I18N {x:Static pixeval:MainPageResources+RestrictedModeItem.Text}}"
@@ -122,13 +121,12 @@
                 </Button>
             </tabView:TabsView.RightHeaderContent>
             <tabView:TabsView.LeftContent>
-                <DockPanel
-                    Margin="5"
-                    HorizontalAlignment="Stretch"
-                    VerticalSpacing="5">
+                <DockPanel x:Name="LeftContentDockPanel" Margin="5" HorizontalAlignment="Stretch" VerticalSpacing="5">
                     <DockPanel.DataTemplates>
                         <DataTemplate x:DataType="{x:Type navigation:NavigationPageItem}">
                             <Button
+                                x:Name="NavButton"
+                                Height="50"
                                 HorizontalAlignment="Stretch"
                                 Background="Transparent"
                                 Command="{x:Static local:TabViewContainer.OpenNavigationItemCommand}"
@@ -152,9 +150,12 @@
                                 </Grid>
                             </Button>
                         </DataTemplate>
-
                         <DataTemplate x:DataType="{x:Type navigation:NavigationFolderItem}">
-                            <Button HorizontalAlignment="Stretch" Background="Transparent">
+                            <Button
+                                x:Name="NavFolderButton"
+                                Height="50"
+                                HorizontalAlignment="Stretch"
+                                Background="Transparent">
                                 <Button.IsEnabled>
                                     <MultiBinding Converter="{x:Static BoolConverters.Or}">
                                         <Binding Path="!NeedLogin" />
@@ -175,9 +176,8 @@
                                 <Button.Flyout>
                                     <MenuFlyout ItemsSource="{Binding Children}" Placement="Right">
                                         <MenuFlyout.ItemContainerTheme>
-                                            <!--  ItemContainerTheme好像会自动向下传递，不需要此处递归指定（也没法递归指定）  -->
                                             <ControlTheme
-                                                x:DataType="{x:Type navigation:NavigationMenuItem}"
+                                                x:DataType="navigation:NavigationMenuItem"
                                                 BasedOn="{StaticResource {x:Type MenuItem}}"
                                                 TargetType="{x:Type MenuItem}">
                                                 <Setter Property="Command" Value="{x:Static local:TabViewContainer.OpenNavigationItemCommand}" />
@@ -202,10 +202,30 @@
                     </DockPanel.DataTemplates>
 
                     <ItemsControl
+                        x:Name="HeaderItemsControl"
+                        DockPanel.Dock="Top"
                         HorizontalAlignment="Stretch"
-                        DockPanel.Dock="Bottom"
+                        ItemsSource="{Binding #Root.HeaderNavigationItems}" />
+                    <ItemsControl
+                        x:Name="FooterItemsControl"
+                        DockPanel.Dock="Top"
+                        HorizontalAlignment="Stretch"
                         ItemsSource="{Binding #Root.FooterNavigationItems}" />
-                    <ItemsControl HorizontalAlignment="Stretch" ItemsSource="{Binding #Root.HeaderNavigationItems}" />
+
+                    <Border x:Name="MoreButtonHost"
+                            DockPanel.Dock="Bottom"
+                            Height="30"
+                            Margin="5,0,5,5"
+                            IsVisible="False">
+                        <Button x:Name="MoreButton"
+                                HorizontalAlignment="Stretch"
+                                Background="Transparent"
+                                BorderThickness="0"
+                                FontWeight="Bold"
+                                FontSize="16">
+                            <TextBlock Text="…" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Button>
+                    </Border>
                 </DockPanel>
             </tabView:TabsView.LeftContent>
         </tabView:TabsView>

--- a/src/Pixeval/Views/ViewContainers/TabViewContainer.axaml.cs
+++ b/src/Pixeval/Views/ViewContainers/TabViewContainer.axaml.cs
@@ -13,6 +13,8 @@ using Avalonia.Controls.Notifications;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
+using Avalonia.Media;
+using Avalonia.Layout;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.DependencyInjection;
 using Pixeval.AppManagement;
@@ -24,6 +26,8 @@ using Pixeval.Views.Login;
 using Pixeval.Views.Settings;
 using Pixeval.Views.Viewers;
 using TabView.Avalonia;
+using FluentIcons.Avalonia;
+using FluentIcons.Common;
 
 namespace Pixeval.Views.ViewContainers;
 
@@ -36,6 +40,9 @@ public partial class TabViewContainer : ViewContainerBase
 
     private NavigationConfiguration _navigationConfiguration = null!;
     private bool _automaticUpdateStarted;
+    private bool _isUpdatingVisibility;
+    private Border? _moreButtonHost;
+    private Button? _moreButton;
 
     public ObservableCollection<NavigationMenuItem> HeaderNavigationItems { get; } = [];
 
@@ -63,6 +70,15 @@ public partial class TabViewContainer : ViewContainerBase
     {
         InitializeComponent();
 
+        _moreButtonHost = this.FindControl<Border>("MoreButtonHost");
+        _moreButton = this.FindControl<Button>("MoreButton");
+
+        if (_moreButton is not null)
+            _moreButton.Click += OnMoreButtonClick;
+
+        if (_moreButtonHost is not null)
+            LeftContentDockPanel.SizeChanged += OnDockPanelSizeChanged;
+
         RebuildNavigation();
 
         AddHandler(
@@ -85,7 +101,6 @@ public partial class TabViewContainer : ViewContainerBase
         TabsControl.InterTabController = set ? new InterTabController { InterTabClient = new PixevalInterTabClient() } : null;
     }
 
-    /// <inheritdoc />
     protected override async void OnLoaded(RoutedEventArgs e)
     {
         base.OnLoaded(e);
@@ -96,6 +111,9 @@ public partial class TabViewContainer : ViewContainerBase
         };
         FlushPendingNotifications();
         RegisterContentDialogHost(TopLevel.GetTopLevel(this));
+
+        await Task.Delay(50);
+        UpdateVisibility();
 
         if (AppInfo.AppVersion.UsesVelopack)
         {
@@ -123,6 +141,168 @@ public partial class TabViewContainer : ViewContainerBase
                 SettingsPage.CreateReleaseNotes(release)));
 
         await Task.WhenAll(dialogTasks);
+    }
+
+    protected override void OnUnloaded(RoutedEventArgs e)
+    {
+        base.OnUnloaded(e);
+        if (LeftContentDockPanel is not null)
+            LeftContentDockPanel.SizeChanged -= OnDockPanelSizeChanged;
+        if (_moreButton is not null)
+            _moreButton.Click -= OnMoreButtonClick;
+    }
+
+    private void OnDockPanelSizeChanged(object? sender, SizeChangedEventArgs e)
+    {
+        UpdateVisibility();
+    }
+
+    private void OnMoreButtonClick(object? sender, RoutedEventArgs e)
+    {
+        if (_moreButton is null) return;
+
+        var flyout = new MenuFlyout { Placement = PlacementMode.TopEdgeAlignedLeft };
+
+        var hiddenItems = GetHiddenItems();
+        if (hiddenItems.Count == 0)
+        {
+            flyout.ItemsSource = null;
+            flyout.ShowAt(_moreButton);
+            return;
+        }
+
+        var menuItems = new List<MenuItem>();
+        foreach (var item in hiddenItems)
+        {
+            var menuItem = CreateMenuItem(item);
+            if (menuItem is not null)
+                menuItems.Add(menuItem);
+        }
+
+        flyout.ItemsSource = menuItems;
+        flyout.ShowAt(_moreButton);
+    }
+
+    private List<object> GetHiddenItems()
+    {
+        var hidden = new List<object>();
+        var allContainers = GetAllContainers();
+        int visibleCount = CalculateVisibleCount(allContainers);
+        if (visibleCount < allContainers.Count)
+            hidden.AddRange(allContainers.Skip(visibleCount).Select(c => c.DataContext));
+        return hidden;
+    }
+
+    private MenuItem? CreateMenuItem(object dataContext)
+    {
+        switch (dataContext)
+        {
+            case NavigationPageItem pageItem:
+                var menuItem = new MenuItem
+                {
+                    Header = pageItem.Header,
+                    Icon = new SymbolIcon { Symbol = pageItem.Icon, IconVariant = IconVariant.Color, FontSize = 16 },
+                    DataContext = pageItem,
+                    IsEnabled = !pageItem.NeedLogin || PixevalSettings.Instance.IsLoggedIn
+                };
+                menuItem.Command = OpenNavigationItemCommand;
+                menuItem.CommandParameter = menuItem;
+                return menuItem;
+
+            case NavigationFolderItem folderItem:
+                var folderMenuItem = new MenuItem
+                {
+                    Header = folderItem.Header,
+                    Icon = new SymbolIcon { Symbol = folderItem.Icon, IconVariant = IconVariant.Color, FontSize = 16 },
+                    DataContext = folderItem,
+                    IsEnabled = !folderItem.NeedLogin || PixevalSettings.Instance.IsLoggedIn
+                };
+                foreach (var child in folderItem.Children)
+                {
+                    var childMenuItem = CreateMenuItem(child);
+                    if (childMenuItem is not null)
+                        folderMenuItem.Items.Add(childMenuItem);
+                }
+                return folderMenuItem;
+
+            default:
+                return null;
+        }
+    }
+
+    private void UpdateVisibility()
+    {
+        if (_isUpdatingVisibility) return;
+        _isUpdatingVisibility = true;
+
+        try
+        {
+            if (_moreButtonHost is null) return;
+            var allContainers = GetAllContainers();
+            if (allContainers.Count == 0 || LeftContentDockPanel.Bounds.Height <= 0)
+            {
+                _moreButtonHost.IsVisible = false;
+                return;
+            }
+
+            int visibleCount = CalculateVisibleCount(allContainers);
+
+            for (int i = 0; i < allContainers.Count; i++)
+                allContainers[i].IsVisible = i < visibleCount;
+
+            _moreButtonHost.IsVisible = visibleCount < allContainers.Count;
+        }
+        finally
+        {
+            _isUpdatingVisibility = false;
+        }
+    }
+
+    private int CalculateVisibleCount(List<Control> allContainers)
+    {
+        double reservedHeight = 40;
+        double available = LeftContentDockPanel.Bounds.Height - reservedHeight;
+        double total = 0;
+        int visibleCount = 0;
+
+        foreach (var c in allContainers)
+        {
+            if (c.DesiredSize.Height <= 0)
+                c.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+        }
+
+        for (int i = 0; i < allContainers.Count; i++)
+        {
+            double h = allContainers[i].DesiredSize.Height > 0 ? allContainers[i].DesiredSize.Height : 40;
+            if (total + h <= available)
+            {
+                total += h;
+                visibleCount++;
+            }
+            else break;
+        }
+
+        return visibleCount;
+    }
+
+    private List<Control> GetAllContainers()
+    {
+        var list = new List<Control>();
+        list.AddRange(GetContainers(HeaderItemsControl));
+        list.AddRange(GetContainers(FooterItemsControl));
+        return list;
+    }
+
+    private List<Control> GetContainers(ItemsControl itemsControl)
+    {
+        var list = new List<Control>();
+        if (itemsControl == null) return list;
+        for (int i = 0; i < itemsControl.Items.Count; i++)
+        {
+            if (itemsControl.ContainerFromIndex(i) is Control c)
+                list.Add(c);
+        }
+        return list;
     }
 
     private void StartAutomaticUpdate()
@@ -162,7 +342,6 @@ public partial class TabViewContainer : ViewContainerBase
         }
     }
 
-    /// <inheritdoc />
     public override void NavigateTo(
         Page page,
         bool removeCurrentPage = false)
@@ -315,11 +494,9 @@ public partial class TabViewContainer : ViewContainerBase
             return;
 
         TabsControl.SelectedIndex = pages.IndexOf(contextPage);
-        // 先固定关闭目标，避免移除页面时索引变化导致关闭范围漂移。
         var targets = TabClosePlanner.GetTargets([.. pages], contextPage, scope);
         foreach (var target in targets)
         {
-            // 复用单标签关闭的释放事件，让页面有机会处理自己的 ViewModel 生命周期。
             var args = new RoutedEventArgs(ViewModelDisposal.RequestDisposeEvent, target);
             target.RaiseEvent(args);
             if (!args.Handled)
@@ -349,12 +526,10 @@ public partial class TabViewContainer : ViewContainerBase
         if (e.Item is not Control control
             || sender.Pages is not IReadOnlyCollection<Page> pages)
             return;
-        // 关闭前手动切换标签页，以便触发标签页的 OnUnloaded 事件并保证其 Parent(TabsView) 存在，以便找 TopLevel(Window) 显示 InfoBar 之类的
         if (sender.SelectedIndex < pages.Count - 1)
             sender.SelectedIndex++;
         else if (sender.SelectedIndex > 0)
             sender.SelectedIndex--;
-        // 否则关闭最后一个标签页，相当于关闭当前窗口，找到 TopLevel(Window) 也没意义
 
         var args = new RoutedEventArgs(ViewModelDisposal.RequestDisposeEvent, control);
         control.RaiseEvent(args);
@@ -390,10 +565,6 @@ public partial class TabViewContainer : ViewContainerBase
         ViewModelDisposal.Dispose(tabItem);
     }
 
-    /// <summary>
-    /// Custom <see cref="IInterTabClient"/> that creates new <see cref="Window"/>
-    /// instances with a fresh <see cref="TabViewContainer"/> for tab tear-off.
-    /// </summary>
     private sealed class PixevalInterTabClient : IInterTabClient
     {
         public TabsHost GetNewHost(InterTabController controller, TabsHost host)


### PR DESCRIPTION
实现左侧导航栏在高度不足时的自动折叠功能。

当侧边栏可用高度不足以显示所有导航项时，超出部分的按钮会自动隐藏，并在底部显示一个 "…"按钮。

像这样：
<img width="130" height="215" alt="image" src="https://github.com/user-attachments/assets/112fb3ca-ad22-4615-bac5-46b44be46160" />
<img width="179" height="152" alt="image" src="https://github.com/user-attachments/assets/4121529f-fdb9-4abc-b207-de39b1762967" />
